### PR TITLE
add min_kdp for 6.6 kernels to fix BT on Samsung devices

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -227,7 +227,31 @@ jobs:
           echo '补丁加入构建'
           echo "obj-y += hmbird_patch.o" >> Makefile
           tail -n 3 Makefile
-      
+
+      - name: Fix Bluetooth and WiFi on Samsung GKI 6.6 devices
+        run: |
+          if [[ "${{ inputs.kernel_version }}" = "6.6" ]]; then
+            echo "Switch to kernel directory"
+            echo "Adding new symbols definitions to GKI symbol lists"
+            cd "$CONFIG/common/"
+            echo "Current directory is $(pwd), downloading patches"
+            curl -LSs "https://github.com/zzh20188/GKI_KernelSU_SUSFS/raw/refs/heads/dev/add_min_kdp_symbols.patch" -o add_min_kdp_symbols.patch
+            patch -p1 < add_min_kdp_symbols.patch
+            echo "Switch to the driver directory"
+            cd "$CONFIG/common/drivers/"
+            echo "Adding min_kdp driver"
+            echo "Current directory is $(pwd), downloading patches"
+            curl -LSs "https://github.com/zzh20188/GKI_KernelSU_SUSFS/raw/refs/heads/dev/min_kdp.c" -o min_kdp.c
+            if [ ! -f min_kdp.c ]; then
+              echo "min_kdp.c download failed"
+            fi
+            echo "Patches added to build"
+            echo "obj-y += min_kdp.o" >> Makefile
+            tail -n 3 Makefile
+          else
+            echo "Skipping min_kdp patches as kernel_version < 6.6"
+          fi
+
       - name: 确定 KernelSU 的分支
         run: |
 

--- a/add-min_kdp-symbols.patch
+++ b/add-min_kdp-symbols.patch
@@ -1,0 +1,85 @@
+From a5c5f6ed347caad90f7b0831f641f5f58bdfe679 Mon Sep 17 00:00:00 2001
+From: Fede2782 <78815152+Fede2782@users.noreply.github.com>
+Date: Wed, 23 Jul 2025 18:35:13 +0200
+Subject: [PATCH] add min_kdp symbols
+
+This adds symbols provided by min_kdp which are required for bluetooth driver
+---
+ android/abi_gki_aarch64.stg    | 35 ++++++++++++++++++++++++++++++++++
+ android/abi_gki_aarch64_galaxy |  3 +++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/android/abi_gki_aarch64.stg b/android/abi_gki_aarch64.stg
+index 78f10f7d9bec..f329bb94a29a 100644
+--- a/android/abi_gki_aarch64.stg
++++ b/android/abi_gki_aarch64.stg
+@@ -352019,6 +352019,11 @@ function {
+   return_type_id: 0x4585663f
+   parameter_id: 0x3e6396e0
+ }
++function {
++  id: 0xc18e39fb
++  return_type_id: 0x4585663f
++  parameter_id: 0x3d551c03
++}
+ function {
+   id: 0xc18f1240
+   return_type_id: 0x4585663f
+@@ -403638,6 +403643,33 @@ elf_symbol {
+   type_id: 0xc59b3a62
+   full_name: "lookup_user_key"
+ }
++elf_symbol {
++  id: 0xb0801f6e
++  name: "kdp_set_cred_non_rcu"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0x738bae5e
++  type_id: 0x1e5195df
++  full_name: "kdp_set_cred_non_rcu"
++}
++elf_symbol {
++  id: 0x3037c5bc
++  name: "kdp_usecount_dec_and_test"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xda582aa5
++  type_id: 0xc18e39fb
++  full_name: "kdp_usecount_dec_and_test"
++}
++elf_symbol {
++  id: 0x8334a496
++  name: "kdp_usecount_inc"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xfb342499
++  type_id: 0x1fcd1693
++  full_name: "kdp_usecount_inc"
++}
+ elf_symbol {
+   id: 0x493ce9fc
+   name: "loops_per_jiffy"
+@@ -441632,6 +441664,9 @@ interface {
+   symbol_id: 0x81dadb36
+   symbol_id: 0x9bfc3a5e
+   symbol_id: 0xc750a072
++  symbol_id: 0xb0801f6e
++  symbol_id: 0x3037c5bc
++  symbol_id: 0x8334a496
+   symbol_id: 0x132eb5f1
+   symbol_id: 0xbccf7511
+   symbol_id: 0xc29558ef
+diff --git a/android/abi_gki_aarch64_galaxy b/android/abi_gki_aarch64_galaxy
+index b39e1faec87d..258fa8b2199b 100644
+--- a/android/abi_gki_aarch64_galaxy
++++ b/android/abi_gki_aarch64_galaxy
+@@ -250,3 +250,6 @@
+   yield
+   regulator_get_current_limit
+   android_create_function_device
++  kdp_set_cred_non_rcu
++  kdp_usecount_dec_and_test
++  kdp_usecount_inc
+-- 
+2.48.1
+

--- a/min_kdp.c
+++ b/min_kdp.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <asm-generic/sections.h>
+#include <linux/mm.h>
+#include "../mm/slab.h"
+#include <linux/slub_def.h>
+#include <linux/binfmts.h>
+
+#include <linux/mount.h>
+#include <linux/cred.h>
+#include <linux/security.h>
+#include <linux/init_task.h>
+#include "../fs/mount.h"
+
+void kdp_usecount_inc(struct cred *cred)
+{
+	atomic_long_inc(&cred->usage);
+}
+EXPORT_SYMBOL(kdp_usecount_inc);
+
+unsigned int kdp_usecount_dec_and_test(struct cred *cred)
+{
+	return atomic_long_dec_and_test(&cred->usage);
+}
+EXPORT_SYMBOL(kdp_usecount_dec_and_test);
+
+void kdp_set_cred_non_rcu(struct cred *cred, int val)
+{
+	cred->non_rcu = val;
+}
+EXPORT_SYMBOL(kdp_set_cred_non_rcu);


### PR DESCRIPTION
Samsung ships a bluetooth drivers which depends on these three KDP functions. So include the non-KDP case of the functions in the kernel to make the shipped module work.

A34 is one of the affected devices (yes, despite being a Samsung mediatek SOME gki kernels work)  