### PR TITLE
修复勾选ZRAM后LTS内核无法编译

### DIFF
--- a/zram/lz4/lz4hc.c
+++ b/zram/lz4/lz4hc.c
@@ -75,8 +75,12 @@ typedef enum { noDictCtx, usingDictCtxHc } dictCtx_directive;
 #define LZ4_OPT_NUM (1 << 12)
 
 /*===   Macros   ===*/
+#ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
 
 /*===   Levels definition   ===*/
 typedef enum { lz4mid, lz4hc, lz4opt } lz4hc_strat_e;


### PR DESCRIPTION
看了下错误日志是 include/linux/minmax.h 与 lib/lz4/lz4hc.c 中的 MIN 和 MAX 定义冲突了，于是加了个 #ifndef 判断