### PR TITLE
Add tmpfs support

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -648,6 +648,10 @@ jobs:
             echo "CONFIG_KPM=y" >> ./common/arch/arm64/configs/gki_defconfig
           fi
 
+          # tmpfs support for mountify
+          echo "CONFIG_TMPFS_XATTR=y" >> ./common/arch/arm64/configs/gki_defconfig
+          echo "CONFIG_TMPFS_POSIX_ACL=y" >> ./common/arch/arm64/configs/gki_defconfig
+
           # Remove check_defconfig
           sed -i 's/check_defconfig//' ./common/build.config.gki
 


### PR DESCRIPTION
Adds the required `CONFIG_*` flags to enable tmpfs support, used by meta-modules like [mountify](https://github.com/backslashxx/mountify), [Hybrid mount](github.com/YuzakiKokuban/meta-hybrid_mount), etc.

I can move the flags into a different CI step if you consider it would be a better way to organize it.