### PR TITLE
fix BBG patch

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -619,7 +619,7 @@ jobs:
           wget -O- https://github.com/vc-teahouse/Baseband-guard/raw/main/setup.sh | bash
           echo "CONFIG_BBG=y" >> common/arch/arm64/configs/gki_defconfig
           
-          sed -i '/^config LSM$/,/^help$/{ /^[[:space:]]*default/ { /baseband_guard/! s/selinux/selinux,baseband_guard/ } }' security/Kconfig
+          sed -i '/^config LSM$/,/^help$/{ /^[[:space:]]*default/ { /baseband_guard/! s/selinux/selinux,baseband_guard/ } }' common/security/Kconfig
 
       - name: 添加配置
         run: |


### PR DESCRIPTION
在 https://github.com/zzh20188/GKI_KernelSU_SUSFS/commit/61ed1d46e91894ee4e60916b1c146f2bfc44635c 之后BBG修补炸了，看了一下是个简单的路径问题，随手修复一下