### PR TITLE
feat: add ZeroMount path redirection support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,10 @@ on:
         required: true
         type: boolean
         default: true
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       supp_op:
         required: false
         type: boolean
@@ -100,6 +104,7 @@ jobs:
           echo "BBG 补丁      : ${{ inputs.use_bbg }}"
           echo "KPM 功能      : ${{ inputs.use_kpm }}"
           echo "Re-Kernel     : ${{ inputs.use_rekernel }}"
+          echo "ZeroMount     : ${{ inputs.add_zeromount }}"
           echo "Droidspaces   : ${{ inputs.droidspaces }}"
           echo "Stock Config  : 自动检测 config/stock_defconfig"
           echo "========================================"
@@ -738,6 +743,18 @@ jobs:
             patch -p1 --forward < "$ACTION_BUILD/patches/unicode_bypass_fix_6.1+.patch" || true
           fi
 
+      - name: 应用 ZeroMount 补丁
+        if: inputs.add_zeromount && inputs.enable_susfs
+        working-directory: ${{ env.KERNEL_ROOT }}/common
+        run: |
+          ZEROMOUNT_PATCH="$GITHUB_WORKSPACE/patches/zeromount/60_zeromount-${{ inputs.android_version }}-${{ inputs.kernel_version }}.patch"
+          if [ -f "$ZEROMOUNT_PATCH" ]; then
+            echo "应用 ZeroMount 补丁: $ZEROMOUNT_PATCH"
+            patch -p1 -F3 --no-backup-if-mismatch < "$ZEROMOUNT_PATCH"
+          else
+            echo "::warning::未找到 ZeroMount 补丁: $ZEROMOUNT_PATCH"
+          fi
+
       - name: 配置 ZRAM LZ4 补丁栈
         if: inputs.use_zram
         working-directory: ${{ env.KERNEL_ROOT }}/common
@@ -952,6 +969,11 @@ jobs:
           CONFIG_KSU_SUSFS_OPEN_REDIRECT=y
           CONFIG_KSU_SUSFS_SUS_MAP=y
           EOF
+
+      - name: 添加 ZeroMount 配置
+        if: inputs.add_zeromount && inputs.enable_susfs
+        run: |
+          echo "CONFIG_ZEROMOUNT=y" >> "$DEFCONFIG"
 
       - name: 配置内核名称
         working-directory: ${{ env.KERNEL_ROOT }}

--- a/.github/workflows/kernel-a12-5-10.yml
+++ b/.github/workflows/kernel-a12-5-10.yml
@@ -60,6 +60,11 @@ on:
         required: true
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         description: "Droidspaces 容器支持"
         required: false
@@ -101,6 +106,10 @@ on:
       cancel_susfs:
         required: false
         type: boolean
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         required: false
         type: string
@@ -202,6 +211,7 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel || false }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount || false }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}
 
   # 仅在直接触发时运行，从 main.yml 调用时跳过

--- a/.github/workflows/kernel-a13-5-15.yml
+++ b/.github/workflows/kernel-a13-5-15.yml
@@ -60,6 +60,11 @@ on:
         required: true
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         description: "Droidspaces 容器支持"
         required: false
@@ -101,6 +106,10 @@ on:
       cancel_susfs:
         required: false
         type: boolean
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         required: false
         type: string
@@ -175,6 +184,7 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel || false }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount || false }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}
 
   # 仅在直接触发时运行，从 main.yml 调用时跳过

--- a/.github/workflows/kernel-a14-6-1.yml
+++ b/.github/workflows/kernel-a14-6-1.yml
@@ -60,6 +60,11 @@ on:
         required: true
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         description: "Droidspaces 容器支持"
         required: false
@@ -101,6 +106,10 @@ on:
       cancel_susfs:
         required: false
         type: boolean
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       droidspaces:
         required: false
         type: string
@@ -179,6 +188,7 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel || false }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount || false }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}
 
   # 仅在直接触发时运行，从 main.yml 调用时跳过

--- a/.github/workflows/kernel-a15-6-6.yml
+++ b/.github/workflows/kernel-a15-6-6.yml
@@ -60,6 +60,11 @@ on:
         required: true
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        required: false
+        type: boolean
+        default: false
       supp_op:
         description: "启用一加 8E 支持"
         required: false
@@ -106,6 +111,10 @@ on:
       cancel_susfs:
         required: false
         type: boolean
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       supp_op:
         required: false
         type: boolean
@@ -171,6 +180,7 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel || false }}
       supp_op: ${{ inputs.supp_op || false }}
       enable_susfs: ${{ !inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount || false }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}
 
   # 仅在直接触发时运行，从 main.yml 调用时跳过

--- a/.github/workflows/kernel-a16-6-12.yml
+++ b/.github/workflows/kernel-a16-6-12.yml
@@ -60,6 +60,11 @@ on:
         required: true
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        required: false
+        type: boolean
+        default: false
       supp_op:
         description: "启用一加 8E 支持"
         required: false
@@ -104,6 +109,10 @@ on:
       cancel_susfs:
         required: false
         type: boolean
+      add_zeromount:
+        required: false
+        type: boolean
+        default: false
       supp_op:
         required: false
         type: boolean
@@ -151,6 +160,7 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel || false }}
       supp_op: ${{ inputs.supp_op || false }}
       enable_susfs: ${{ !inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount || false }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}
 
   # 仅在直接触发时运行，从 main.yml 调用时跳过

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,10 @@ on:
         description: "禁用 SUSFS"
         type: boolean
         default: false
+      add_zeromount:
+        description: "启用 ZeroMount 路径重定向"
+        type: boolean
+        default: false
       droidspaces:
         description: "Droidspaces 容器支持 (5.10~6.6: 槽位补丁, 6.12: 开/关)"
         type: choice
@@ -142,6 +146,7 @@ jobs:
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount }}
       droidspaces: ${{ inputs.droidspaces }}
       called_from_main: true
 
@@ -160,6 +165,7 @@ jobs:
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount }}
       droidspaces: ${{ inputs.droidspaces }}
       called_from_main: true
 
@@ -178,6 +184,7 @@ jobs:
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount }}
       droidspaces: ${{ inputs.droidspaces }}
       called_from_main: true
 
@@ -196,6 +203,7 @@ jobs:
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount }}
       droidspaces: ${{ inputs.droidspaces }}
       called_from_main: true
 
@@ -214,6 +222,7 @@ jobs:
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
+      add_zeromount: ${{ inputs.add_zeromount }}
       droidspaces: ${{ inputs.droidspaces }}
       called_from_main: true
 

--- a/patches/zeromount/60_zeromount-android12-5.10.patch
+++ b/patches/zeromount/60_zeromount-android12-5.10.patch
@@ -1,0 +1,2227 @@
+diff --git a/fs/Kconfig b/fs/Kconfig
+index 5e4dea4cf..ff3c8adde 100644
+--- a/fs/Kconfig
++++ b/fs/Kconfig
+@@ -350,6 +350,13 @@ source "fs/unicode/Kconfig"
+ config IO_WQ
+ 	bool
+ 
++config ZEROMOUNT
++	bool "ZeroMount Path Redirection Subsystem"
++	default y
++	help
++	  ZeroMount allows path redirection and virtual file injection
++	  without mounting filesystems. Useful for systemless modifications.
++
+ endmenu
+ 
+ config KSU_SUSFS_SUS_KSTAT_REDIRECT
+diff --git a/fs/Makefile b/fs/Makefile
+index e951f5487..5cf04de70 100644
+--- a/fs/Makefile
++++ b/fs/Makefile
+@@ -139,3 +139,4 @@ obj-$(CONFIG_EFIVAR_FS)		+= efivarfs/
+ obj-$(CONFIG_EROFS_FS)		+= erofs/
+ obj-$(CONFIG_VBOXSF_FS)		+= vboxsf/
+ obj-$(CONFIG_ZONEFS_FS)		+= zonefs/
++obj-$(CONFIG_ZEROMOUNT)		+= zeromount.o
+diff --git a/fs/d_path.c b/fs/d_path.c
+index a69e2cd36..11678ff56 100644
+--- a/fs/d_path.c
++++ b/fs/d_path.c
+@@ -8,6 +8,10 @@
+ #include <linux/prefetch.h>
+ #include "mount.h"
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ static int prepend(char **buffer, int *buflen, const char *str, int namelen)
+ {
+ 	*buflen -= namelen;
+@@ -265,6 +269,26 @@ char *d_path(const struct path *path, char *buf, int buflen)
+ 	struct path root;
+ 	int error;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (path->dentry && d_backing_inode(path->dentry)) {
++		char *v_path = zeromount_get_static_vpath(d_backing_inode(path->dentry));
++
++		if (v_path) {
++			int len = strlen(v_path);
++			if (buflen < len + 1) {
++				kfree(v_path);
++				return ERR_PTR(-ENAMETOOLONG);
++			}
++			*--res = '\0';
++			res -= len;
++			memcpy(res, v_path, len);
++			kfree(v_path);
++			return res;
++		}
++	}
++#endif
++
++
+ 	/*
+ 	 * We have various synthetic filesystems that never get mounted.  On
+ 	 * these filesystems dentries are never used for lookup purposes, and
+diff --git a/fs/namei.c b/fs/namei.c
+index 3dfde472b..81e8e5547 100644
+--- a/fs/namei.c
++++ b/fs/namei.c
+@@ -49,6 +49,10 @@
+ #include "internal.h"
+ #include "mount.h"
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ #define CREATE_TRACE_POINTS
+ #include <trace/events/namei.h>
+ 
+@@ -214,6 +218,13 @@ getname_flags(const char __user *filename, int flags, int *empty)
+ 	result->uptr = filename;
+ 	result->aname = NULL;
+ 	audit_getname(result);
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!IS_ERR(result)) {
++		result = zeromount_getname_hook(result);
++	}
++#endif
++
+ 	return result;
+ }
+ 
+@@ -361,6 +372,18 @@ int generic_permission(struct inode *inode, int mask)
+ {
+ 	int ret;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	/*
+ 	 * Do the basic permission checks.
+ 	 */
+@@ -454,6 +477,18 @@ int inode_permission(struct inode *inode, int mask)
+ {
+ 	int retval;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	retval = sb_permission(inode->i_sb, inode, mask);
+ 	if (retval)
+ 		return retval;
+diff --git a/fs/proc/base.c b/fs/proc/base.c
+index 156ce6286..373978ce5 100644
+--- a/fs/proc/base.c
++++ b/fs/proc/base.c
+@@ -102,6 +102,9 @@
+ #endif
+ #include <trace/events/oom.h>
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include "fd.h"
+ 
+ #include "../../lib/kstrtox.h"
+@@ -1791,6 +1794,27 @@ static int do_proc_readlink(struct path *path, char __user *buffer, int buflen)
+ 	if (!tmp)
+ 		return -ENOMEM;
+ 
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!zeromount_should_skip() && path->dentry) {
++		struct inode *inode = d_backing_inode(path->dentry);
++		if (inode) {
++			char *vpath = zeromount_get_static_vpath(inode);
++			if (vpath) {
++				int vlen = strlen(vpath);
++				if (vlen > buflen)
++					vlen = buflen;
++				if (copy_to_user(buffer, vpath, vlen) == 0) {
++					kfree(vpath);
++					free_page((unsigned long)tmp);
++					return vlen;
++				}
++				kfree(vpath);
++			}
++		}
++	}
++#endif
++
+ 	pathname = d_path(path, tmp, PAGE_SIZE);
+ 	len = PTR_ERR(pathname);
+ 	if (IS_ERR(pathname))
+diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
+index 7cb00fe68..fd8d787e7 100644
+--- a/fs/proc/task_mmu.c
++++ b/fs/proc/task_mmu.c
+@@ -19,6 +19,9 @@
+ #include <linux/shmem_fs.h>
+ #include <linux/uaccess.h>
+ #include <linux/pkeys.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #if defined(CONFIG_KSU_SUSFS_SUS_KSTAT) || defined(CONFIG_KSU_SUSFS_SUS_MAP)
+ #include <linux/susfs_def.h>
+ #endif
+@@ -366,6 +369,9 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
+ #endif
+ 		dev = inode->i_sb->s_dev;
+ 		ino = inode->i_ino;
++#ifdef CONFIG_ZEROMOUNT
++		zeromount_spoof_mmap_metadata(inode, &dev, &ino);
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ bypass_orig_flow:
+ #endif
+diff --git a/fs/readdir.c b/fs/readdir.c
+index e5a56fcfc..d0fca7da3 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -21,6 +21,9 @@
+ #include <linux/unistd.h>
+ #include <linux/compat.h>
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include <asm/unaligned.h>
+ 
+@@ -323,17 +326,37 @@ SYSCALL_DEFINE3(getdents, unsigned int, fd,
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -343,6 +366,9 @@ SYSCALL_DEFINE3(getdents, unsigned int, fd,
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -420,17 +446,37 @@ SYSCALL_DEFINE3(getdents64, unsigned int, fd,
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents64(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent64 __user * lastdirent;
+ 		typeof(lastdirent->d_off) d_off = buf.ctx.pos;
+@@ -441,6 +487,9 @@ SYSCALL_DEFINE3(getdents64, unsigned int, fd,
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -614,17 +663,37 @@ COMPAT_SYSCALL_DEFINE3(getdents, unsigned int, fd,
+ 		.count = count
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct compat_linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -634,6 +703,9 @@ COMPAT_SYSCALL_DEFINE3(getdents, unsigned int, fd,
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+diff --git a/fs/stat.c b/fs/stat.c
+index 9c699e632..c4a5678b8 100644
+--- a/fs/stat.c
++++ b/fs/stat.c
+@@ -26,6 +26,9 @@
+ #endif
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <asm/unistd.h>
+ 
+ #include "internal.h"
+@@ -217,6 +220,41 @@ extern int ksu_handle_stat(int *dfd, const char __user **filename_user, int *fla
+  *
+  * 0 will be returned on success, and a -ve error code if unsuccessful.
+  */
++#ifdef CONFIG_ZEROMOUNT
++static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
++                                      struct kstat *stat, unsigned int request_mask, 
++                                      int flags) {
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
++    if (filename) {
++        char kname[NAME_MAX + 1];
++        long copied = strncpy_from_user(kname, filename, sizeof(kname));
++        if (copied > 0 && kname[0] != '/') {
++            char *abs_path = zeromount_build_absolute_path(dfd, kname);
++            if (abs_path) {
++                char *resolved = zeromount_resolve_path(abs_path);
++                if (resolved) {
++                    struct path zm_path;
++                    int zm_ret;
++                    zm_enter();
++                    zm_ret = kern_path(resolved, (flags & AT_SYMLINK_NOFOLLOW) ? 0 : LOOKUP_FOLLOW, &zm_path);
++                    zm_exit();
++                    kfree(resolved);
++                    kfree(abs_path);
++                    if (zm_ret == 0) {
++                        zm_ret = vfs_getattr(&zm_path, stat, request_mask,
++                                             (flags & AT_SYMLINK_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
++                        path_put(&zm_path);
++                        return zm_ret;
++                    }
++                } else {
++                    kfree(abs_path);
++                }
++            }
++        }
++    }
++    return -ENOENT;
++}
++#endif
+ static int vfs_statx(int dfd, const char __user *filename, int flags,
+ 	      struct kstat *stat, u32 request_mask)
+ {
+@@ -224,6 +262,16 @@ static int vfs_statx(int dfd, const char __user *filename, int flags,
+ 	unsigned lookup_flags = 0;
+ 	int error;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	/* Try ZeroMount hook for relative paths */
++	if (filename) {
++		int zm_ret = zeromount_stat_hook(dfd, filename, stat, request_mask, flags);
++		if (zm_ret != -ENOENT)
++			return zm_ret;
++	}
++#endif
++
++
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ 	if (susfs_check_unicode_bypass(filename)) {
+ 		return -ENOENT;
+diff --git a/fs/statfs.c b/fs/statfs.c
+index a21875ca3..093287941 100644
+--- a/fs/statfs.c
++++ b/fs/statfs.c
+@@ -14,6 +14,9 @@
+ #include "mount.h"
+ #endif
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static int flags_by_mnt(int mnt_flags)
+ {
+@@ -118,7 +121,14 @@ int user_statfs(const char __user *pathname, struct kstatfs *st)
+ retry:
+ 	error = user_path_at(AT_FDCWD, pathname, lookup_flags, &path);
+ 	if (!error) {
++#ifdef CONFIG_ZEROMOUNT
++		int spoofed;
++#endif
+ 		error = vfs_statfs(&path, st);
++#ifdef CONFIG_ZEROMOUNT
++		spoofed = zeromount_spoof_statfs(pathname, st);
++		(void)spoofed;
++#endif
+ 		path_put(&path);
+ 		if (retry_estale(error, lookup_flags)) {
+ 			lookup_flags |= LOOKUP_REVAL;
+diff --git a/fs/xattr.c b/fs/xattr.c
+index 8d7151492..e21419bd7 100644
+--- a/fs/xattr.c
++++ b/fs/xattr.c
+@@ -24,6 +24,9 @@
+ #include <linux/posix_acl_xattr.h>
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static const char *
+ strcmp_prefix(const char *a, const char *a_prefix)
+@@ -403,6 +406,12 @@ EXPORT_SYMBOL(__vfs_getxattr);
+ ssize_t
+ vfs_getxattr(struct dentry *dentry, const char *name, void *value, size_t size)
+ {
++#ifdef CONFIG_ZEROMOUNT
++	ssize_t zm_ret;
++	zm_ret = zeromount_spoof_xattr(dentry, name, value, size);
++	if (zm_ret != -EOPNOTSUPP)
++		return zm_ret;
++#endif
+ 	return __vfs_getxattr(dentry, dentry->d_inode, name, value, size, 0);
+ }
+ EXPORT_SYMBOL_NS_GPL(vfs_getxattr, ANDROID_GKI_VFS_EXPORT_ONLY);
+diff --git a/fs/zeromount.c b/fs/zeromount.c
+new file mode 100644
+index 000000000..0b596ea48
+--- /dev/null
++++ b/fs/zeromount.c
+@@ -0,0 +1,1526 @@
++#include <linux/module.h>
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/fs.h>
++#include <linux/dcache.h>
++#include <linux/path.h>
++#include <linux/namei.h>
++#include <linux/sched.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/uaccess.h>
++#include <linux/dirent.h>
++#include <linux/miscdevice.h>
++#include <linux/cred.h>
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include <linux/zeromount.h>
++#include <linux/kobject.h>
++#include <linux/sysfs.h>
++#include <linux/statfs.h>
++#include <linux/file.h>
++#include <linux/fs_struct.h>
++#ifdef CONFIG_KSU_SUSFS
++#include <linux/susfs.h>
++#endif
++#include <linux/reboot.h>
++#include <linux/bitmap.h>
++
++int zeromount_debug_level = 0;
++
++DEFINE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++LIST_HEAD(zeromount_rules_list);
++DEFINE_SPINLOCK(zeromount_lock);
++
++atomic_t zeromount_enabled = ATOMIC_INIT(0);
++static atomic_t zeromount_dirs_count = ATOMIC_INIT(0);
++static atomic_t zeromount_rule_count = ATOMIC_INIT(0);
++static DECLARE_BITMAP(zm_bloom, ZM_BLOOM_BITS);
++#define ZEROMOUNT_DISABLED() (atomic_read(&zeromount_enabled) == 0)
++
++static inline void zm_bloom_add(u32 hash)
++{
++	set_bit(hash & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static inline bool zm_bloom_test(u32 hash)
++{
++	return test_bit(hash & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static void zm_bloom_rebuild(void)
++{
++	struct zeromount_rule *rule;
++	int count = 0;
++
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		u32 h = full_name_hash(NULL, rule->virtual_path, rule->vp_len);
++		zm_bloom_add(h);
++		count++;
++	}
++	ZM_DBG("bloom: rebuilt (%d rules)\n", count);
++}
++
++struct linux_dirent {
++	unsigned long	d_ino;
++	unsigned long	d_off;
++	unsigned short	d_reclen;
++	char		d_name[];
++};
++
++static unsigned long zm_ino_adb = 0;
++static unsigned long zm_ino_modules = 0;
++
++static inline bool zeromount_is_critical_process(void)
++{
++	const char *comm = current->comm;
++
++	switch (comm[0]) {
++	case 'i': if (comm[1] == 'n' && comm[2] == 'i') return true; break;
++	case 'u': if (comm[1] == 'e' && comm[2] == 'v') return true; break;
++	case 'v': if (comm[1] == 'o' && comm[2] == 'l') return true; break;
++	}
++	if (current->flags & PF_KTHREAD)
++		return true;
++	return false;
++}
++
++bool zeromount_should_skip(void)
++{
++	if (ZEROMOUNT_DISABLED())
++		return true;
++	if (zm_is_recursive())
++		return true;
++	if (unlikely(in_interrupt() || in_nmi() || oops_in_progress))
++		return true;
++	if (!current || !current->mm)
++		return true;
++	if (current->flags & PF_EXITING)
++		return true;
++	if (zeromount_is_critical_process())
++		return true;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return true;
++#endif
++	return false;
++}
++EXPORT_SYMBOL(zeromount_should_skip);
++
++bool zeromount_is_uid_blocked(uid_t uid)
++{
++	struct zeromount_uid_node *entry;
++
++	if (ZEROMOUNT_DISABLED())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return true;
++#endif
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_uid_ht, entry, node, uid) {
++		if (entry->uid == uid) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_uid_blocked);
++
++bool zeromount_match_path(const char *input_path, const char *rule_path)
++{
++	if (!input_path || !rule_path)
++		return false;
++	if (strcmp(input_path, rule_path) == 0)
++		return true;
++	if (strncmp(input_path, "/system", 7) == 0) {
++		if (strcmp(input_path + 7, rule_path) == 0)
++			return true;
++	}
++	return false;
++}
++
++/* Zero-alloc normalize: compute adjusted base and length in-place */
++static inline void zeromount_normalize_inline(const char *path,
++					      const char **out_p,
++					      size_t *out_len)
++{
++	const char *p = path;
++	size_t len;
++
++	if (strncmp(path, "/system/", 8) == 0)
++		p = path + 7;
++
++	len = strlen(p);
++	while (len > 1 && p[len - 1] == '/')
++		len--;
++
++	*out_p = p;
++	*out_len = len;
++}
++
++/* Alloc variant for callers that need a persistent copy */
++static char *zeromount_normalize_path(const char *path)
++{
++	const char *p;
++	size_t len;
++	char *normalized;
++
++	if (!path)
++		return NULL;
++
++	zeromount_normalize_inline(path, &p, &len);
++
++	normalized = kmalloc(len + 1, GFP_KERNEL);
++	if (!normalized)
++		return NULL;
++
++	memcpy(normalized, p, len);
++	normalized[len] = '\0';
++	return normalized;
++}
++
++static void zeromount_free_rule_rcu(struct rcu_head *head)
++{
++	struct zeromount_rule *rule = container_of(head, struct zeromount_rule, rcu);
++
++	kfree(rule->virtual_path);
++	kfree(rule->real_path);
++	kfree(rule);
++}
++
++static void zeromount_free_child_rcu(struct rcu_head *head)
++{
++	struct zeromount_child_name *child =
++		container_of(head, struct zeromount_child_name, rcu);
++
++	kfree(child->name);
++	kfree(child);
++}
++
++static void zeromount_free_dir_node_rcu(struct rcu_head *head)
++{
++	struct zeromount_dir_node *node =
++		container_of(head, struct zeromount_dir_node, rcu);
++
++	kfree(node->dir_path);
++	kfree(node);
++}
++
++static void zeromount_flush_parent(const char *full_path)
++{
++	char *path_copy, *last_slash, *parent_str, *child_name;
++	struct path parent;
++
++	path_copy = kstrdup(full_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_str = path_copy;
++	child_name = last_slash + 1;
++
++	if (*child_name == '\0') {
++		kfree(path_copy);
++		return;
++	}
++
++	if (kern_path(parent_str, LOOKUP_FOLLOW, &parent) == 0) {
++		struct dentry *child;
++
++		inode_lock(parent.dentry->d_inode);
++		child = lookup_one_len(child_name, parent.dentry,
++				       strlen(child_name));
++		if (!IS_ERR(child)) {
++			d_invalidate(child);
++			d_drop(child);
++			dput(child);
++		}
++		inode_unlock(parent.dentry->d_inode);
++		path_put(&parent);
++	}
++
++	kfree(path_copy);
++}
++
++static void zeromount_flush_dcache(const char *path_name)
++{
++	struct path path;
++	int err;
++
++	zm_enter();
++	err = kern_path(path_name, LOOKUP_FOLLOW, &path);
++	if (!err) {
++		d_invalidate(path.dentry);
++		d_drop(path.dentry);
++		path_put(&path);
++	} else if (err == -ENOENT) {
++		zeromount_flush_parent(path_name);
++	}
++	zm_exit();
++}
++
++static void zeromount_force_refresh_all(void)
++{
++	struct zeromount_rule *rule;
++	char **paths = NULL;
++	int count = 0, i = 0;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list)
++		count++;
++	spin_unlock(&zeromount_lock);
++
++	if (count == 0)
++		return;
++
++	paths = kvmalloc_array(count, sizeof(char *), GFP_KERNEL);
++	if (!paths)
++		return;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		if (i >= count)
++			break;
++		paths[i] = kstrdup(rule->virtual_path, GFP_ATOMIC);
++		if (!paths[i])
++			break;
++		i++;
++	}
++	spin_unlock(&zeromount_lock);
++
++	for (count = i, i = 0; i < count; i++) {
++		zeromount_flush_dcache(paths[i]);
++		kfree(paths[i]);
++	}
++	kvfree(paths);
++}
++
++static unsigned long zeromount_generate_ino(const char *dir, const char *name)
++{
++	u32 h1 = full_name_hash(NULL, dir, strlen(dir));
++	u32 h2 = full_name_hash(NULL, name, strlen(name));
++
++	return (unsigned long)(h1 ^ h2);
++}
++
++char *zeromount_get_virtual_path_for_inode(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *found_path = NULL;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return NULL;
++	if (zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			if (READ_ONCE(rule->is_new))
++				found_path = kstrdup(rule->virtual_path,
++						     GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return found_path;
++}
++EXPORT_SYMBOL(zeromount_get_virtual_path_for_inode);
++
++/* Returns kstrdup'd copy; caller must kfree. GFP_ATOMIC safe from any context. */
++char *zeromount_get_static_vpath(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *copy = NULL;
++
++	if (unlikely(!inode || !inode->i_sb))
++		return NULL;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			copy = kstrdup(rule->virtual_path, GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return copy;
++}
++EXPORT_SYMBOL(zeromount_get_static_vpath);
++
++/* Spoof dev/ino in /proc/PID/maps for redirected mmap'd files */
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (unlikely(!inode || !dev || !ino))
++		return;
++	if (zeromount_should_skip())
++		return;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			*dev = READ_ONCE(rule->v_dev);
++			*ino = READ_ONCE(rule->v_ino);
++			break;
++		}
++	}
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(zeromount_spoof_mmap_metadata);
++
++static unsigned long zeromount_get_inode_by_path(const char *path_str)
++{
++	struct path path;
++	struct inode *inode;
++	unsigned long ino = 0;
++
++	if (kern_path(path_str, LOOKUP_FOLLOW, &path) == 0) {
++		inode = d_backing_inode(path.dentry);
++		if (inode)
++			ino = inode->i_ino;
++		path_put(&path);
++	}
++	return ino;
++}
++
++static void zeromount_refresh_critical_inodes(void)
++{
++	if (READ_ONCE(zm_ino_adb) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_adb, ino);
++	}
++	if (READ_ONCE(zm_ino_modules) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb/modules");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_modules, ino);
++	}
++}
++
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask)
++{
++	if (!inode || zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return false;
++#endif
++	if (!(mask & MAY_EXEC))
++		return false;
++
++	if ((READ_ONCE(zm_ino_adb) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_adb)) ||
++	    (READ_ONCE(zm_ino_modules) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_modules)))
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_traversal_allowed);
++
++bool zeromount_is_injected_file(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return false;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return false;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_injected_file);
++
++char *zeromount_resolve_path(const char *pathname)
++{
++	struct zeromount_rule *rule;
++	char *target = NULL;
++	const char *normalized;
++	size_t norm_len;
++	u32 hash;
++
++	if (zeromount_is_critical_process())
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++	if (ZEROMOUNT_DISABLED() ||
++	    zeromount_is_uid_blocked(current_uid().val) || !pathname)
++		return NULL;
++
++	zeromount_normalize_inline(pathname, &normalized, &norm_len);
++	hash = full_name_hash(NULL, normalized, norm_len);
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	if (!zm_bloom_test(hash)) {
++		ZM_TRACE("bloom: reject hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++		return NULL;
++	}
++	ZM_DBG("bloom: pass hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_rules_ht, rule, node, hash) {
++		if (rule->vp_len == norm_len &&
++		    memcmp(normalized, rule->virtual_path, norm_len) == 0) {
++			if (rule->flags & ZM_FLAG_ACTIVE) {
++				target = kstrdup(rule->real_path, GFP_ATOMIC);
++				break;
++			}
++		}
++	}
++	rcu_read_unlock();
++	return target;
++}
++EXPORT_SYMBOL(zeromount_resolve_path);
++
++static char *zeromount_resolve_dirfd_path(int dfd, char *buf, int buflen)
++{
++	struct fd f;
++	char *path;
++
++	if (dfd == AT_FDCWD) {
++		struct path pwd;
++
++		if (unlikely(!current->fs))
++			return ERR_PTR(-ENOENT);
++		get_fs_pwd(current->fs, &pwd);
++		path = d_path(&pwd, buf, buflen);
++		path_put(&pwd);
++		return path;
++	}
++
++	f = fdget(dfd);
++	if (!f.file)
++		return ERR_PTR(-EBADF);
++
++	path = d_path(&f.file->f_path, buf, buflen);
++	fdput(f);
++	return path;
++}
++
++char *zeromount_build_absolute_path(int dfd, const char *name)
++{
++	char *page_buf, *dir_path, *abs_path;
++	size_t dir_len, name_len;
++
++	if (!name || name[0] == '/' || *name == '\0')
++		return NULL;
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return NULL;
++
++	dir_path = zeromount_resolve_dirfd_path(dfd, page_buf, PATH_MAX);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	dir_len = strlen(dir_path);
++	name_len = strlen(name);
++
++	if (dir_len > PATH_MAX || name_len > NAME_MAX ||
++	    dir_len + name_len + 2 > PATH_MAX) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	abs_path = kmalloc(dir_len + 1 + name_len + 1, GFP_KERNEL);
++	if (abs_path) {
++		memcpy(abs_path, dir_path, dir_len);
++		abs_path[dir_len] = '/';
++		memcpy(abs_path + dir_len + 1, name, name_len + 1);
++	}
++
++	__putname(page_buf);
++	return abs_path;
++}
++EXPORT_SYMBOL(zeromount_build_absolute_path);
++
++struct filename *zeromount_getname_hook(struct filename *name)
++{
++	char *target_path;
++	struct filename *new_name;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val) ||
++	    !name || name->name[0] != '/')
++		return name;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return name;
++#endif
++
++	zm_enter();
++
++	target_path = zeromount_resolve_path(name->name);
++	if (!target_path) {
++		zm_exit();
++		return name;
++	}
++
++	new_name = getname_kernel(target_path);
++	kfree(target_path);
++
++	if (IS_ERR(new_name)) {
++		zm_exit();
++		return name;
++	}
++
++	putname(name);
++	zm_exit();
++	return new_name;
++}
++
++/* Merged readdir injection: compat=0 for dirent64, compat=1 for dirent */
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat)
++{
++	char *page_buf, *dir_path;
++	unsigned long v_index;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return;
++#endif
++
++	if (atomic_read(&zeromount_dirs_count) == 0 &&
++	    *pos < ZEROMOUNT_MAGIC_POS)
++		return;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return;
++
++	dir_path = d_path(&file->f_path, page_buf, PAGE_SIZE);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return;
++	}
++
++	/* Skip if this directory is itself redirected */
++	{
++		const char *norm_p;
++		size_t norm_len;
++		u32 dir_hash;
++		bool is_redirected = false;
++
++		zeromount_normalize_inline(dir_path, &norm_p, &norm_len);
++		dir_hash = full_name_hash(NULL, norm_p, norm_len);
++
++		rcu_read_lock();
++		{
++			struct zeromount_rule *rule;
++
++			hash_for_each_possible_rcu(zeromount_rules_ht, rule,
++						   node, dir_hash) {
++				if (rule->vp_len == norm_len &&
++				    memcmp(norm_p, rule->virtual_path,
++					   norm_len) == 0 &&
++				    (rule->flags & ZM_FLAG_ACTIVE)) {
++					is_redirected = true;
++					break;
++				}
++			}
++		}
++		rcu_read_unlock();
++
++		if (is_redirected) {
++			__putname(page_buf);
++			return;
++		}
++	}
++
++	if (*pos >= ZEROMOUNT_MAGIC_POS) {
++		v_index = *pos - ZEROMOUNT_MAGIC_POS;
++	} else {
++		v_index = 0;
++	}
++
++	{
++		struct zeromount_dir_node *zm_dir;
++		struct zeromount_child_name *zm_child;
++		const char *normalized;
++		size_t normalized_len;
++		u32 zm_hash;
++		unsigned long cur_idx = 0;
++
++		zeromount_normalize_inline(dir_path, &normalized,
++					  &normalized_len);
++		zm_hash = full_name_hash(NULL, normalized, normalized_len);
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_dirs_ht, zm_dir,
++					   node, zm_hash) {
++			if (strlen(zm_dir->dir_path) != normalized_len ||
++			    memcmp(normalized, zm_dir->dir_path,
++				   normalized_len) != 0)
++				continue;
++
++			if (*pos < ZEROMOUNT_MAGIC_POS)
++				*pos = ZEROMOUNT_MAGIC_POS;
++
++			list_for_each_entry_rcu(zm_child,
++						&zm_dir->children_names,
++						list) {
++				char name_local[256];
++				unsigned char type_local;
++				int name_len, reclen;
++				unsigned long fake_ino;
++
++				if (cur_idx++ < v_index)
++					continue;
++
++				strscpy(name_local, zm_child->name,
++					sizeof(name_local));
++				type_local = zm_child->d_type;
++				name_len = strlen(name_local);
++
++				if (compat) {
++					struct linux_dirent __user *de;
++
++					reclen = ALIGN(offsetof(struct linux_dirent, d_name) + name_len + 2, 4);
++					if (*count < reclen)
++						break;
++					de = (struct linux_dirent __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de->d_off) ||
++					    put_user(reclen, &de->d_reclen) ||
++					    copy_to_user(de->d_name, name_local, name_len) ||
++					    put_user(0, de->d_name + name_len) ||
++					    put_user(type_local, ((char __user *)de) + reclen - 1))
++						break;
++				} else {
++					struct linux_dirent64 __user *de64;
++
++					reclen = ALIGN(offsetof(struct linux_dirent64, d_name) + name_len + 1, sizeof(u64));
++					if (*count < reclen)
++						break;
++					de64 = (struct linux_dirent64 __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de64->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de64->d_off) ||
++					    put_user(reclen, &de64->d_reclen) ||
++					    put_user(type_local, &de64->d_type) ||
++					    copy_to_user(de64->d_name, name_local, name_len) ||
++					    put_user(0, de64->d_name + name_len))
++						break;
++				}
++
++				*dirent = (void __user *)((char __user *)*dirent + reclen);
++				*count -= reclen;
++				v_index++;
++				*pos = ZEROMOUNT_MAGIC_POS + v_index;
++			}
++			break;
++		}
++		rcu_read_unlock();
++	}
++
++	__putname(page_buf);
++}
++
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 0);
++}
++
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 1);
++}
++
++#define EROFS_SUPER_MAGIC 0xE0F5E1E2
++#define EXT4_SUPER_MAGIC  0xEF53
++#define F2FS_SUPER_MAGIC  0xF2F52010
++
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf)
++{
++	char *kpath;
++	char *resolved;
++	int ret = 0;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return 0;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return 0;
++#endif
++
++	kpath = strndup_user(pathname, PATH_MAX);
++	if (IS_ERR(kpath))
++		return 0;
++
++	resolved = zeromount_resolve_path(kpath);
++	if (!resolved) {
++		kfree(kpath);
++		return 0;
++	}
++
++	if (strncmp(kpath, "/system", 7) == 0 ||
++	    strncmp(kpath, "/vendor", 7) == 0 ||
++	    strncmp(kpath, "/product", 8) == 0 ||
++	    strncmp(kpath, "/odm", 4) == 0) {
++		buf->f_type = EROFS_SUPER_MAGIC;
++		ret = 1;
++	}
++
++	kfree(kpath);
++	kfree(resolved);
++	return ret;
++}
++EXPORT_SYMBOL(zeromount_spoof_statfs);
++
++static const char *zeromount_get_selinux_context(const char *vpath)
++{
++	if (!vpath)
++		return NULL;
++
++	if (strncmp(vpath, "/lib64", 6) == 0 ||
++	    strncmp(vpath, "/lib", 4) == 0)
++		return "u:object_r:system_lib_file:s0";
++
++	if (strncmp(vpath, "/bin", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/fonts", 6) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/framework", 10) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/etc", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/vendor", 7) == 0)
++		return "u:object_r:vendor_file:s0";
++
++	if (strncmp(vpath, "/product", 8) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (vpath[0] == '/')
++		return "u:object_r:system_file:s0";
++
++	return NULL;
++}
++
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size)
++{
++	struct inode *inode;
++	char *vpath;
++	const char *context;
++	size_t ctx_len;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return -EOPNOTSUPP;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return -EOPNOTSUPP;
++#endif
++
++	if (!dentry || !name)
++		return -EOPNOTSUPP;
++
++	if (strcmp(name, "security.selinux") != 0)
++		return -EOPNOTSUPP;
++
++	inode = d_backing_inode(dentry);
++	if (!inode)
++		return -EOPNOTSUPP;
++
++	vpath = zeromount_get_virtual_path_for_inode(inode);
++	if (!vpath)
++		return -EOPNOTSUPP;
++
++	context = zeromount_get_selinux_context(vpath);
++	kfree(vpath);
++
++	if (!context)
++		return -EOPNOTSUPP;
++
++	ctx_len = strlen(context) + 1;
++
++	if (size == 0)
++		return ctx_len;
++	if (size < ctx_len)
++		return -ERANGE;
++
++	memcpy(value, context, ctx_len);
++	return ctx_len;
++}
++EXPORT_SYMBOL(zeromount_spoof_xattr);
++
++static void zeromount_auto_inject_parent(const char *v_path,
++					 unsigned char type, int depth)
++{
++	char *parent_path, *name, *path_copy, *last_slash;
++	struct zeromount_dir_node *dir_node = NULL, *curr;
++	struct zeromount_child_name *child;
++	u32 hash;
++	bool child_exists = false;
++
++	if (depth > 20)
++		return;
++
++	/* Existing path on real fs means all ancestors exist too */
++	{
++		struct path check;
++		if (kern_path(v_path, LOOKUP_FOLLOW, &check) == 0) {
++			path_put(&check);
++			return;
++		}
++	}
++
++	path_copy = kstrdup(v_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_path = path_copy;
++	name = last_slash + 1;
++
++	/* Skip if parent dir is VFS-redirected */
++	{
++		u32 parent_hash = full_name_hash(NULL, parent_path,
++						 strlen(parent_path));
++		struct zeromount_rule *parent_rule;
++		bool parent_redirected = false;
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_rules_ht, parent_rule,
++					   node, parent_hash) {
++			if (strcmp(parent_rule->virtual_path, parent_path) == 0 &&
++			    READ_ONCE(parent_rule->is_new)) {
++				parent_redirected = true;
++				break;
++			}
++		}
++		rcu_read_unlock();
++
++		if (parent_redirected) {
++			kfree(path_copy);
++			return;
++		}
++	}
++
++	zeromount_auto_inject_parent(parent_path, DT_DIR, depth + 1);
++
++	hash = full_name_hash(NULL, parent_path, strlen(parent_path));
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_possible(zeromount_dirs_ht, curr, node, hash) {
++		if (strcmp(curr->dir_path, parent_path) == 0) {
++			dir_node = curr;
++			break;
++		}
++	}
++
++	if (!dir_node) {
++		dir_node = kzalloc(sizeof(*dir_node), GFP_ATOMIC);
++		if (!dir_node)
++			goto unlock_out;
++
++		dir_node->dir_path = kstrdup(parent_path, GFP_ATOMIC);
++		INIT_LIST_HEAD(&dir_node->children_names);
++		hash_add_rcu(zeromount_dirs_ht, &dir_node->node, hash);
++		atomic_inc(&zeromount_dirs_count);
++	}
++
++	list_for_each_entry(child, &dir_node->children_names, list) {
++		if (strcmp(child->name, name) == 0) {
++			child_exists = true;
++			break;
++		}
++	}
++
++	if (!child_exists) {
++		child = kzalloc(sizeof(*child), GFP_ATOMIC);
++		if (child) {
++			child->name = kstrdup(name, GFP_ATOMIC);
++			child->d_type = (type == DT_DIR) ? 4 : 8;
++			list_add_tail_rcu(&child->list,
++					  &dir_node->children_names);
++		}
++	}
++
++unlock_out:
++	spin_unlock(&zeromount_lock);
++	kfree(path_copy);
++}
++
++static int zeromount_ioctl_add_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule;
++	char *v_path_raw, *v_path, *r_path;
++	struct path path;
++	unsigned char type;
++	u32 hash;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	r_path = strndup_user(data.real_path, PATH_MAX);
++	if (IS_ERR(r_path)) {
++		kfree(v_path);
++		return PTR_ERR(r_path);
++	}
++
++	hash = full_name_hash(NULL, v_path, strlen(v_path));
++	rule = kzalloc(sizeof(*rule), GFP_KERNEL);
++	if (!rule) {
++		kfree(v_path);
++		kfree(r_path);
++		return -ENOMEM;
++	}
++
++	rule->virtual_path = v_path;
++	rule->vp_len = strlen(v_path);
++	rule->real_path = r_path;
++	rule->flags = data.flags | ZM_FLAG_ACTIVE;
++	rule->is_new = false;
++
++	if (zm_ino_adb == 0)
++		zeromount_refresh_critical_inodes();
++
++	if (kern_path(r_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *inode = d_backing_inode(path.dentry);
++
++		if (inode) {
++			rule->real_ino = inode->i_ino;
++			rule->real_dev = inode->i_sb->s_dev;
++		}
++		path_put(&path);
++	} else {
++		rule->real_ino = 0;
++		rule->real_dev = 0;
++	}
++
++	/* Capture virtual path's dev/ino for maps spoofing.
++	 * Replacement rules use real inode; injected files use
++	 * parent device + generated ino. */
++	zm_enter();
++	if (kern_path(v_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *vinode = d_backing_inode(path.dentry);
++
++		if (vinode) {
++			rule->v_ino = vinode->i_ino;
++			rule->v_dev = vinode->i_sb->s_dev;
++		}
++		path_put(&path);
++	}
++	zm_exit();
++
++	if (rule->v_ino == 0) {
++		rule->v_ino = zeromount_generate_ino(v_path, r_path);
++		{
++			char *parent_copy = kstrdup(v_path, GFP_KERNEL);
++
++			if (parent_copy) {
++				char *slash = strrchr(parent_copy, '/');
++
++				if (slash && slash != parent_copy) {
++					*slash = '\0';
++					zm_enter();
++					if (kern_path(parent_copy, LOOKUP_FOLLOW,
++						      &path) == 0) {
++						struct inode *pinode =
++							d_backing_inode(path.dentry);
++						if (pinode)
++							rule->v_dev = pinode->i_sb->s_dev;
++						path_put(&path);
++					}
++					zm_exit();
++				}
++				kfree(parent_copy);
++			}
++		}
++	}
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_rules_ht, &rule->node, hash);
++	zm_bloom_add(hash);
++	ZM_DBG("bloom: add hash=0x%08x path=%s\n", hash, rule->virtual_path);
++	if (rule->real_ino != 0) {
++		unsigned long ino_key = rule->real_ino ^ rule->real_dev;
++
++		hash_add_rcu(zeromount_ino_ht, &rule->ino_node, ino_key);
++	}
++	list_add_tail(&rule->list, &zeromount_rules_list);
++	atomic_inc(&zeromount_rule_count);
++	spin_unlock(&zeromount_lock);
++
++	type = DT_REG;
++	if (data.flags & ZM_FLAG_IS_DIR)
++		type = DT_DIR;
++
++	if (kern_path(rule->virtual_path, LOOKUP_FOLLOW, &path) == 0) {
++		path_put(&path);
++	} else {
++		zeromount_auto_inject_parent(rule->virtual_path, type, 0);
++		WRITE_ONCE(rule->is_new, true);
++	}
++	zeromount_flush_dcache(rule->virtual_path);
++	return 0;
++}
++
++static void zeromount_cleanup_parent_dir(char *v_path)
++{
++	char *end = v_path + strlen(v_path);
++	char *last_slash, *p;
++	struct zeromount_dir_node *dir_node;
++	struct zeromount_child_name *child, *tmp_child;
++	u32 hash;
++	bool pruned;
++
++	do {
++		pruned = false;
++		last_slash = strrchr(v_path, '/');
++		if (!last_slash || last_slash == v_path)
++			break;
++
++		*last_slash = '\0';
++		hash = full_name_hash(NULL, v_path, strlen(v_path));
++
++		hash_for_each_possible(zeromount_dirs_ht, dir_node,
++				       node, hash) {
++			if (strcmp(dir_node->dir_path, v_path) != 0)
++				continue;
++
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				if (strcmp(child->name, last_slash + 1) == 0) {
++					list_del_rcu(&child->list);
++					call_rcu(&child->rcu,
++						 zeromount_free_child_rcu);
++					break;
++				}
++			}
++
++			if (list_empty(&dir_node->children_names)) {
++				hash_del_rcu(&dir_node->node);
++				atomic_dec(&zeromount_dirs_count);
++				call_rcu(&dir_node->rcu,
++					 zeromount_free_dir_node_rcu);
++				pruned = true;
++			}
++			break;
++		}
++	} while (pruned);
++
++	for (p = v_path; p < end; p++)
++		if (*p == '\0')
++			*p = '/';
++}
++
++static int zeromount_ioctl_del_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule = NULL;
++	struct hlist_node *tmp;
++	char *v_path_raw, *v_path;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		if (strcmp(rule->virtual_path, v_path) == 0) {
++			hash_del_rcu(&rule->node);
++			if (rule->real_ino != 0)
++				hash_del_rcu(&rule->ino_node);
++			list_del(&rule->list);
++			found = true;
++			break;
++		}
++	}
++	if (found)
++		zeromount_cleanup_parent_dir(v_path);
++	if (found)
++		atomic_dec(&zeromount_rule_count);
++	zm_bloom_rebuild();
++	spin_unlock(&zeromount_lock);
++
++	if (found && rule)
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++
++	kfree(v_path);
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_clear_rules(void)
++{
++	struct zeromount_rule *rule;
++	struct zeromount_uid_node *uid_node;
++	struct hlist_node *tmp;
++	int bkt;
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		hash_del_rcu(&rule->node);
++		if (rule->real_ino != 0)
++			hash_del_rcu(&rule->ino_node);
++		list_del(&rule->list);
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++	}
++
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, uid_node, node) {
++		hash_del_rcu(&uid_node->node);
++		kfree_rcu(uid_node, rcu);
++	}
++
++	{
++		struct zeromount_dir_node *dir_node;
++		struct zeromount_child_name *child, *tmp_child;
++		int bkt2;
++		struct hlist_node *tmp2;
++
++		hash_for_each_safe(zeromount_dirs_ht, bkt2, tmp2,
++				   dir_node, node) {
++			hash_del_rcu(&dir_node->node);
++			atomic_dec(&zeromount_dirs_count);
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				list_del_rcu(&child->list);
++				call_rcu(&child->rcu,
++					 zeromount_free_child_rcu);
++			}
++			call_rcu(&dir_node->rcu,
++				 zeromount_free_dir_node_rcu);
++		}
++	}
++
++	atomic_set(&zeromount_rule_count, 0);
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	spin_unlock(&zeromount_lock);
++	return 0;
++}
++
++static int zeromount_ioctl_list_rules(unsigned long arg)
++{
++	struct zeromount_rule *rule;
++	char *kbuf;
++	int ret = 0;
++	size_t len = 0;
++	size_t remaining;
++	char __user *ubuf = (char __user *)arg;
++
++	kbuf = vmalloc(MAX_LIST_BUFFER_SIZE);
++	if (!kbuf)
++		return -ENOMEM;
++
++	memset(kbuf, 0, MAX_LIST_BUFFER_SIZE);
++	spin_lock(&zeromount_lock);
++
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		remaining = MAX_LIST_BUFFER_SIZE - len;
++		if (remaining <= 1) {
++			ret = -ENOBUFS;
++			break;
++		}
++		len += scnprintf(kbuf + len, remaining, "%s->%s\n",
++				 rule->real_path, rule->virtual_path);
++	}
++
++	spin_unlock(&zeromount_lock);
++
++	if (ret == -ENOBUFS) {
++		vfree(kbuf);
++		return ret;
++	}
++
++	if (copy_to_user(ubuf, kbuf, len))
++		ret = -EFAULT;
++	else
++		ret = len;
++
++	vfree(kbuf);
++	return ret;
++}
++
++static int zeromount_ioctl_add_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++	if (zeromount_is_uid_blocked(uid))
++		return -EEXIST;
++
++	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return -ENOMEM;
++
++	entry->uid = uid;
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_uid_ht, &entry->node, uid);
++	spin_unlock(&zeromount_lock);
++
++	return 0;
++}
++
++static int zeromount_ioctl_del_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++	struct hlist_node *tmp;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, entry, node) {
++		if (entry->uid == uid) {
++			hash_del_rcu(&entry->node);
++			found = true;
++			break;
++		}
++	}
++	spin_unlock(&zeromount_lock);
++
++	if (found && entry)
++		kfree_rcu(entry, rcu);
++
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_enable(void)
++{
++	atomic_set(&zeromount_enabled, 1);
++	return 0;
++}
++
++static int zeromount_ioctl_disable(void)
++{
++	atomic_set(&zeromount_enabled, 0);
++	return 0;
++}
++
++static long zeromount_ioctl(struct file *filp, unsigned int cmd,
++			    unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) != ZEROMOUNT_MAGIC_CODE)
++		return -ENOTTY;
++
++	if (cmd != ZEROMOUNT_IOC_GET_VERSION) {
++		if (!capable(CAP_SYS_ADMIN))
++			return -EPERM;
++	}
++
++	switch (cmd) {
++	case ZEROMOUNT_IOC_GET_VERSION:	return ZEROMOUNT_VERSION;
++	case ZEROMOUNT_IOC_ADD_RULE:	return zeromount_ioctl_add_rule(arg);
++	case ZEROMOUNT_IOC_DEL_RULE:	return zeromount_ioctl_del_rule(arg);
++	case ZEROMOUNT_IOC_CLEAR_ALL:	return zeromount_ioctl_clear_rules();
++	case ZEROMOUNT_IOC_ADD_UID:	return zeromount_ioctl_add_uid(arg);
++	case ZEROMOUNT_IOC_DEL_UID:	return zeromount_ioctl_del_uid(arg);
++	case ZEROMOUNT_IOC_GET_LIST:	return zeromount_ioctl_list_rules(arg);
++	case ZEROMOUNT_IOC_ENABLE:	return zeromount_ioctl_enable();
++	case ZEROMOUNT_IOC_DISABLE:	return zeromount_ioctl_disable();
++	case ZEROMOUNT_IOC_REFRESH:
++		zeromount_force_refresh_all();
++		return 0;
++	case ZEROMOUNT_IOC_GET_STATUS:	return atomic_read(&zeromount_enabled);
++	default:			return -EINVAL;
++	}
++}
++
++static struct kobject *zeromount_kobj;
++
++static ssize_t debug_show(struct kobject *kobj, struct kobj_attribute *attr,
++			  char *buf)
++{
++	return sprintf(buf, "%d\n", zeromount_debug_level);
++}
++
++static ssize_t debug_store(struct kobject *kobj, struct kobj_attribute *attr,
++			   const char *buf, size_t count)
++{
++	int val;
++
++	if (kstrtoint(buf, 10, &val) < 0)
++		return -EINVAL;
++	if (val < 0 || val > 2)
++		return -EINVAL;
++	zeromount_debug_level = val;
++	return count;
++}
++
++static struct kobj_attribute debug_attr =
++	__ATTR(debug, 0600, debug_show, debug_store);
++
++static struct attribute *zeromount_attrs[] = {
++	&debug_attr.attr,
++	NULL,
++};
++
++static struct attribute_group zeromount_attr_group = {
++	.attrs = zeromount_attrs,
++};
++
++static int zeromount_dev_open(struct inode *inode, struct file *file)
++{
++	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
++		return -EPERM;
++	return 0;
++}
++
++static const struct file_operations zeromount_fops = {
++	.owner		= THIS_MODULE,
++	.open		= zeromount_dev_open,
++	.unlocked_ioctl	= zeromount_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl	= zeromount_ioctl,
++#endif
++};
++
++static struct miscdevice zeromount_device = {
++	.minor	= MISC_DYNAMIC_MINOR,
++	.name	= "zeromount",
++	.fops	= &zeromount_fops,
++	.mode	= 0600,
++};
++
++static int zeromount_reboot_notify(struct notifier_block *nb,
++				   unsigned long action, void *data)
++{
++	atomic_set(&zeromount_enabled, 0);
++	synchronize_rcu();
++	return NOTIFY_OK;
++}
++
++static struct notifier_block zeromount_reboot_nb = {
++	.notifier_call = zeromount_reboot_notify,
++};
++
++static int __init __used zeromount_init(void)
++{
++	int ret;
++
++	spin_lock_init(&zeromount_lock);
++	register_reboot_notifier(&zeromount_reboot_nb);
++
++	ret = misc_register(&zeromount_device);
++	if (ret)
++		return ret;
++
++	zeromount_kobj = kobject_create_and_add("zeromount", kernel_kobj);
++	if (zeromount_kobj) {
++		ret = sysfs_create_group(zeromount_kobj,
++					&zeromount_attr_group);
++		if (ret)
++			pr_warn("ZeroMount: sysfs group creation failed: %d\n",
++				ret);
++	}
++
++	ZM_INFO("Loaded (debug=%d)\n", zeromount_debug_level);
++	return 0;
++}
++fs_initcall(zeromount_init);
++
+diff --git a/include/linux/zeromount.h b/include/linux/zeromount.h
+new file mode 100644
+index 000000000..01fd6aca0
+--- /dev/null
++++ b/include/linux/zeromount.h
+@@ -0,0 +1,200 @@
++#ifndef _LINUX_ZEROMOUNT_H
++#define _LINUX_ZEROMOUNT_H
++
++#include <linux/types.h>
++#include <linux/list.h>
++#include <linux/hashtable.h>
++#include <linux/spinlock.h>
++#include <linux/limits.h>
++#include <linux/atomic.h>
++#include <linux/uidgid.h>
++#include <linux/stat.h>
++#include <linux/ioctl.h>
++#include <linux/rcupdate.h>
++#include <linux/printk.h>
++#include <linux/sched.h>
++#include <linux/bitops.h>
++
++#define ZM_BLOOM_BITS     4096
++#define ZM_BLOOM_SHIFT    12
++#define ZM_BLOOM_MASK     (ZM_BLOOM_BITS - 1)
++
++/* Per-task recursion guard using android_oem_data1 bit 0.
++ * Survives CPU migration -- no preemption constraints needed. */
++#ifdef CONFIG_ANDROID_VENDOR_OEM_DATA
++#define ZM_RECURSIVE_BIT 0
++
++static inline void zm_enter(void)
++{
++	set_bit(ZM_RECURSIVE_BIT,
++		(unsigned long *)&current->android_oem_data1);
++}
++
++static inline void zm_exit(void)
++{
++	clear_bit(ZM_RECURSIVE_BIT,
++		  (unsigned long *)&current->android_oem_data1);
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return test_bit(ZM_RECURSIVE_BIT,
++			(unsigned long *)&current->android_oem_data1);
++}
++#else
++#define ZM_RECURSIVE_MARKER ((void *)0x5A4D)
++
++/* Only claim journal_info if it is free — avoids clobbering jbd2 handles
++ * held by user processes doing ext4 I/O. If already occupied, we treat
++ * the call as a no-op; zm_is_recursive() returns false so ZeroMount
++ * proceeds normally, which is safe since the occupied handle means we
++ * are in a filesystem transaction context where redirection is unwanted. */
++static inline void zm_enter(void)
++{
++	if (!current->journal_info)
++		current->journal_info = ZM_RECURSIVE_MARKER;
++}
++
++static inline void zm_exit(void)
++{
++	if (current->journal_info == ZM_RECURSIVE_MARKER)
++		current->journal_info = NULL;
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return current->journal_info == ZM_RECURSIVE_MARKER;
++}
++#endif
++
++extern int zeromount_debug_level;
++
++#define ZM_LOG(level, fmt, ...) \
++	do { \
++		if (zeromount_debug_level >= (level) && printk_ratelimit()) \
++			pr_info("ZeroMount: " fmt, ##__VA_ARGS__); \
++	} while (0)
++
++#define ZM_TRACE(fmt, ...) ZM_LOG(3, fmt, ##__VA_ARGS__)
++#define ZM_DBG(fmt, ...)  ZM_LOG(2, fmt, ##__VA_ARGS__)
++#define ZM_INFO(fmt, ...) ZM_LOG(1, fmt, ##__VA_ARGS__)
++#define ZM_ERR(fmt, ...)  pr_err("ZeroMount: " fmt, ##__VA_ARGS__)
++
++#define ZEROMOUNT_MAGIC_CODE	0x5A
++#define ZEROMOUNT_VERSION	1
++#define ZEROMOUNT_HASH_BITS	10
++#define ZM_FLAG_ACTIVE		(1 << 0)
++#define ZM_FLAG_IS_DIR		(1 << 7)
++#define ZEROMOUNT_MAGIC_POS	0x7000000000000000ULL
++
++#define ZEROMOUNT_IOC_MAGIC	ZEROMOUNT_MAGIC_CODE
++#define ZEROMOUNT_IOC_ADD_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 1, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_DEL_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 2, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_CLEAR_ALL	_IO(ZEROMOUNT_IOC_MAGIC, 3)
++#define ZEROMOUNT_IOC_GET_VERSION _IOR(ZEROMOUNT_IOC_MAGIC, 4, int)
++#define ZEROMOUNT_IOC_ADD_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 5, unsigned int)
++#define ZEROMOUNT_IOC_DEL_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 6, unsigned int)
++#define ZEROMOUNT_IOC_GET_LIST	_IOR(ZEROMOUNT_IOC_MAGIC, 7, int)
++#define ZEROMOUNT_IOC_ENABLE	_IO(ZEROMOUNT_IOC_MAGIC, 8)
++#define ZEROMOUNT_IOC_DISABLE	_IO(ZEROMOUNT_IOC_MAGIC, 9)
++#define ZEROMOUNT_IOC_REFRESH	_IO(ZEROMOUNT_IOC_MAGIC, 10)
++#define ZEROMOUNT_IOC_GET_STATUS _IOR(ZEROMOUNT_IOC_MAGIC, 11, int)
++#define MAX_LIST_BUFFER_SIZE	(64 * 1024)
++
++struct zeromount_ioctl_data {
++	char __user *virtual_path;
++	char __user *real_path;
++	unsigned int flags;
++};
++
++struct zeromount_rule {
++	struct hlist_node node;
++	struct hlist_node ino_node;
++	struct list_head list;
++	size_t vp_len;
++	char *virtual_path;
++	char *real_path;
++	unsigned long real_ino;
++	dev_t real_dev;
++	unsigned long v_ino;
++	dev_t v_dev;
++	bool is_new;
++	u32 flags;
++	struct rcu_head rcu;
++};
++
++struct zeromount_dir_node {
++	struct hlist_node node;
++	char *dir_path;
++	struct list_head children_names;
++	struct rcu_head rcu;
++};
++
++struct zeromount_child_name {
++	struct list_head list;
++	char *name;
++	unsigned char d_type;
++	struct rcu_head rcu;
++};
++
++struct zeromount_uid_node {
++	uid_t uid;
++	struct hlist_node node;
++	struct rcu_head rcu;
++};
++
++extern DECLARE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++extern struct list_head zeromount_rules_list;
++extern spinlock_t zeromount_lock;
++
++#ifdef CONFIG_ZEROMOUNT
++extern atomic_t zeromount_enabled;
++
++bool zeromount_should_skip(void);
++char *zeromount_resolve_path(const char *pathname);
++char *zeromount_build_absolute_path(int dfd, const char *name);
++struct filename *zeromount_getname_hook(struct filename *name);
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat);
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos);
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos);
++char *zeromount_get_virtual_path_for_inode(struct inode *inode);
++char *zeromount_get_static_vpath(struct inode *inode);
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino);
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask);
++bool zeromount_is_injected_file(struct inode *inode);
++bool zeromount_is_uid_blocked(uid_t uid);
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf);
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size);
++#else
++static inline bool zeromount_should_skip(void) { return true; }
++static inline char *zeromount_resolve_path(const char *p) { return NULL; }
++static inline char *zeromount_build_absolute_path(int dfd, const char *name) { return NULL; }
++static inline struct filename *zeromount_getname_hook(struct filename *name) { return name; }
++static inline void zeromount_inject_dents_common(struct file *f, void __user **d,
++						 int *c, loff_t *p, int compat) {}
++static inline void zeromount_inject_dents64(struct file *f, void __user **d,
++					    int *c, loff_t *p) {}
++static inline void zeromount_inject_dents(struct file *f, void __user **d,
++					  int *c, loff_t *p) {}
++static inline char *zeromount_get_virtual_path_for_inode(struct inode *inode) { return NULL; }
++static inline char *zeromount_get_static_vpath(struct inode *inode) { return NULL; }
++static inline void zeromount_spoof_mmap_metadata(struct inode *inode,
++						 dev_t *dev,
++						 unsigned long *ino) {}
++static inline bool zeromount_is_traversal_allowed(struct inode *inode, int mask) { return false; }
++static inline bool zeromount_is_injected_file(struct inode *inode) { return false; }
++static inline bool zeromount_is_uid_blocked(uid_t uid) { return false; }
++static inline int zeromount_spoof_statfs(const char __user *p, struct kstatfs *b) { return 0; }
++static inline ssize_t zeromount_spoof_xattr(struct dentry *d, const char *n,
++					    void *v, size_t s) { return -EOPNOTSUPP; }
++#endif
++
++#endif /* _LINUX_ZEROMOUNT_H */

--- a/patches/zeromount/60_zeromount-android13-5.15.patch
+++ b/patches/zeromount/60_zeromount-android13-5.15.patch
@@ -1,0 +1,2215 @@
+diff -ruN a/fs/Kconfig b/fs/Kconfig
+--- a/fs/Kconfig	2026-03-01 01:55:42.442043732 +0100
++++ b/fs/Kconfig	2026-03-01 02:17:15.316592068 +0100
+@@ -387,6 +387,13 @@
+ config IO_WQ
+ 	bool
+ 
++config ZEROMOUNT
++	bool "ZeroMount Path Redirection Subsystem"
++	default y
++	help
++	  ZeroMount allows path redirection and virtual file injection
++	  without mounting filesystems. Useful for systemless modifications.
++
+ endmenu
+ 
+ config KSU_SUSFS_SUS_KSTAT_REDIRECT
+diff -ruN a/fs/Makefile b/fs/Makefile
+--- a/fs/Makefile	2026-03-01 01:44:52.236884082 +0100
++++ b/fs/Makefile	2026-03-01 02:17:15.316672321 +0100
+@@ -141,3 +141,4 @@
+ obj-$(CONFIG_EROFS_FS)		+= erofs/
+ obj-$(CONFIG_VBOXSF_FS)		+= vboxsf/
+ obj-$(CONFIG_ZONEFS_FS)		+= zonefs/
++obj-$(CONFIG_ZEROMOUNT)		+= zeromount.o
+diff -ruN a/fs/d_path.c b/fs/d_path.c
+--- a/fs/d_path.c	2026-02-16 21:53:29.373254396 +0100
++++ b/fs/d_path.c	2026-03-01 02:18:20.928720976 +0100
+@@ -8,6 +8,10 @@
+ #include <linux/prefetch.h>
+ #include "mount.h"
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ struct prepend_buffer {
+ 	char *buf;
+ 	int len;
+@@ -268,6 +272,25 @@
+ 	DECLARE_BUFFER(b, buf, buflen);
+ 	struct path root;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (path->dentry && d_backing_inode(path->dentry)) {
++		char *v_path = zeromount_get_static_vpath(d_backing_inode(path->dentry));
++
++		if (v_path) {
++			int len = strlen(v_path);
++			if (buflen < len + 1) {
++				kfree(v_path);
++				return ERR_PTR(-ENAMETOOLONG);
++			}
++			memcpy(buf, v_path, len);
++			buf[len] = '\0';
++			kfree(v_path);
++			return buf;
++		}
++	}
++#endif
++
++
+ 	/*
+ 	 * We have various synthetic filesystems that never get mounted.  On
+ 	 * these filesystems dentries are never used for lookup purposes, and
+diff -ruN a/fs/namei.c b/fs/namei.c
+--- a/fs/namei.c	2026-03-01 02:03:06.768302489 +0100
++++ b/fs/namei.c	2026-03-01 02:17:15.317317009 +0100
+@@ -49,6 +49,10 @@
+ #include "internal.h"
+ #include "mount.h"
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ extern bool susfs_is_inode_sus_path(struct inode *inode);
+ extern const struct qstr susfs_fake_qstr_name;
+@@ -211,6 +215,13 @@
+ 	result->uptr = filename;
+ 	result->aname = NULL;
+ 	audit_getname(result);
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!IS_ERR(result)) {
++		result = zeromount_getname_hook(result);
++	}
++#endif
++
+ 	return result;
+ }
+ 
+@@ -410,6 +421,18 @@
+ {
+ 	int ret;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	/*
+ 	 * Do the basic permission checks.
+ 	 */
+@@ -514,6 +537,18 @@
+ {
+ 	int retval;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	retval = sb_permission(inode->i_sb, inode, mask);
+ 	if (retval)
+ 		return retval;
+diff -ruN a/fs/proc/base.c b/fs/proc/base.c
+--- a/fs/proc/base.c	2026-03-01 01:44:52.239045660 +0100
++++ b/fs/proc/base.c	2026-03-01 02:17:15.317764186 +0100
+@@ -105,6 +105,9 @@
+ #endif
+ #include <trace/events/oom.h>
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include "fd.h"
+ 
+ #include "../../lib/kstrtox.h"
+@@ -1856,6 +1859,27 @@
+ 	if (!tmp)
+ 		return -ENOMEM;
+ 
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!zeromount_should_skip() && path->dentry) {
++		struct inode *inode = d_backing_inode(path->dentry);
++		if (inode) {
++			char *vpath = zeromount_get_static_vpath(inode);
++			if (vpath) {
++				int vlen = strlen(vpath);
++				if (vlen > buflen)
++					vlen = buflen;
++				if (copy_to_user(buffer, vpath, vlen) == 0) {
++					kfree(vpath);
++					free_page((unsigned long)tmp);
++					return vlen;
++				}
++				kfree(vpath);
++			}
++		}
++	}
++#endif
++
+ 	pathname = d_path(path, tmp, PAGE_SIZE);
+ 	len = PTR_ERR(pathname);
+ 	if (IS_ERR(pathname))
+diff -ruN a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
+--- a/fs/proc/task_mmu.c	2026-03-01 01:44:52.239593177 +0100
++++ b/fs/proc/task_mmu.c	2026-03-01 02:17:15.317996421 +0100
+@@ -21,6 +21,9 @@
+ #include <linux/shmem_fs.h>
+ #include <linux/uaccess.h>
+ #include <linux/pkeys.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #if defined(CONFIG_KSU_SUSFS_SUS_KSTAT) || defined(CONFIG_KSU_SUSFS_SUS_MAP)
+ #include <linux/susfs_def.h>
+ #endif
+@@ -318,6 +321,9 @@
+ #endif
+ 		dev = inode->i_sb->s_dev;
+ 		ino = inode->i_ino;
++#ifdef CONFIG_ZEROMOUNT
++		zeromount_spoof_mmap_metadata(inode, &dev, &ino);
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ bypass_orig_flow:
+ #endif
+diff -ruN a/fs/readdir.c b/fs/readdir.c
+--- a/fs/readdir.c	2026-03-01 01:55:24.634434134 +0100
++++ b/fs/readdir.c	2026-03-01 02:17:15.318177391 +0100
+@@ -21,6 +21,9 @@
+ #include <linux/unistd.h>
+ #include <linux/compat.h>
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include <asm/unaligned.h>
+ 
+@@ -323,17 +326,37 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -343,6 +366,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -420,17 +446,37 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents64(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent64 __user * lastdirent;
+ 		typeof(lastdirent->d_off) d_off = buf.ctx.pos;
+@@ -441,6 +487,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -614,17 +663,37 @@
+ 		.count = count
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct compat_linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -634,6 +703,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+diff -ruN a/fs/stat.c b/fs/stat.c
+--- a/fs/stat.c	2026-03-01 02:06:14.988176024 +0100
++++ b/fs/stat.c	2026-03-01 02:17:15.318350115 +0100
+@@ -24,6 +24,9 @@
+ #endif
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <asm/unistd.h>
+ 
+ #include "internal.h"
+@@ -242,6 +245,41 @@
+  *
+  * 0 will be returned on success, and a -ve error code if unsuccessful.
+  */
++#ifdef CONFIG_ZEROMOUNT
++static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
++                                      struct kstat *stat, unsigned int request_mask, 
++                                      int flags) {
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
++    if (filename) {
++        char kname[NAME_MAX + 1];
++        long copied = strncpy_from_user(kname, filename, sizeof(kname));
++        if (copied > 0 && kname[0] != '/') {
++            char *abs_path = zeromount_build_absolute_path(dfd, kname);
++            if (abs_path) {
++                char *resolved = zeromount_resolve_path(abs_path);
++                if (resolved) {
++                    struct path zm_path;
++                    int zm_ret;
++                    zm_enter();
++                    zm_ret = kern_path(resolved, (flags & AT_SYMLINK_NOFOLLOW) ? 0 : LOOKUP_FOLLOW, &zm_path);
++                    zm_exit();
++                    kfree(resolved);
++                    kfree(abs_path);
++                    if (zm_ret == 0) {
++                        zm_ret = vfs_getattr(&zm_path, stat, request_mask,
++                                             (flags & AT_SYMLINK_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
++                        path_put(&zm_path);
++                        return zm_ret;
++                    }
++                } else {
++                    kfree(abs_path);
++                }
++            }
++        }
++    }
++    return -ENOENT;
++}
++#endif
+ static int vfs_statx(int dfd, const char __user *filename, int flags,
+ 	      struct kstat *stat, u32 request_mask)
+ {
+@@ -249,6 +287,16 @@
+ 	unsigned lookup_flags = 0;
+ 	int error;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	/* Try ZeroMount hook for relative paths */
++	if (filename) {
++		int zm_ret = zeromount_stat_hook(dfd, filename, stat, request_mask, flags);
++		if (zm_ret != -ENOENT)
++			return zm_ret;
++	}
++#endif
++
++
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ 	if (susfs_check_unicode_bypass(filename)) {
+ 		return -ENOENT;
+diff -ruN a/fs/statfs.c b/fs/statfs.c
+--- a/fs/statfs.c	2026-03-01 01:44:52.240844306 +0100
++++ b/fs/statfs.c	2026-03-01 02:17:15.318471401 +0100
+@@ -14,6 +14,9 @@
+ #include "mount.h"
+ #endif
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static int flags_by_mnt(int mnt_flags)
+ {
+@@ -118,7 +121,14 @@
+ retry:
+ 	error = user_path_at(AT_FDCWD, pathname, lookup_flags, &path);
+ 	if (!error) {
++#ifdef CONFIG_ZEROMOUNT
++		int spoofed;
++#endif
+ 		error = vfs_statfs(&path, st);
++#ifdef CONFIG_ZEROMOUNT
++		spoofed = zeromount_spoof_statfs(pathname, st);
++		(void)spoofed;
++#endif
+ 		path_put(&path);
+ 		if (retry_estale(error, lookup_flags)) {
+ 			lookup_flags |= LOOKUP_REVAL;
+diff -ruN a/fs/xattr.c b/fs/xattr.c
+--- a/fs/xattr.c	2026-02-16 21:53:29.501251588 +0100
++++ b/fs/xattr.c	2026-03-01 02:18:17.844778487 +0100
+@@ -24,6 +24,9 @@
+ #include <linux/posix_acl_xattr.h>
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include "internal.h"
+ 
+@@ -409,6 +412,15 @@
+ 	struct inode *inode = dentry->d_inode;
+ 	int error;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	{
++		ssize_t zm_ret;
++		zm_ret = zeromount_spoof_xattr(dentry, name, value, size);
++		if (zm_ret != -EOPNOTSUPP)
++			return zm_ret;
++	}
++#endif
++
+ 	error = xattr_permission(mnt_userns, inode, name, MAY_READ);
+ 	if (error)
+ 		return error;
+diff -ruN a/fs/zeromount.c b/fs/zeromount.c
+--- a/fs/zeromount.c	1970-01-01 01:00:00.000000000 +0100
++++ b/fs/zeromount.c	2026-03-01 02:20:44.370462718 +0100
+@@ -0,0 +1,1526 @@
++#include <linux/module.h>
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/fs.h>
++#include <linux/dcache.h>
++#include <linux/path.h>
++#include <linux/namei.h>
++#include <linux/sched.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/uaccess.h>
++#include <linux/dirent.h>
++#include <linux/miscdevice.h>
++#include <linux/cred.h>
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include <linux/zeromount.h>
++#include <linux/kobject.h>
++#include <linux/sysfs.h>
++#include <linux/statfs.h>
++#include <linux/file.h>
++#include <linux/fs_struct.h>
++#ifdef CONFIG_KSU_SUSFS
++#include <linux/susfs.h>
++#endif
++#include <linux/reboot.h>
++#include <linux/bitmap.h>
++
++int zeromount_debug_level = 0;
++
++DEFINE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++LIST_HEAD(zeromount_rules_list);
++DEFINE_SPINLOCK(zeromount_lock);
++
++atomic_t zeromount_enabled = ATOMIC_INIT(0);
++static atomic_t zeromount_dirs_count = ATOMIC_INIT(0);
++static atomic_t zeromount_rule_count = ATOMIC_INIT(0);
++static DECLARE_BITMAP(zm_bloom, ZM_BLOOM_BITS);
++#define ZEROMOUNT_DISABLED() (atomic_read(&zeromount_enabled) == 0)
++
++static inline void zm_bloom_add(u32 hash)
++{
++	set_bit(hash & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static inline bool zm_bloom_test(u32 hash)
++{
++	return test_bit(hash & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static void zm_bloom_rebuild(void)
++{
++	struct zeromount_rule *rule;
++	int count = 0;
++
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		u32 h = full_name_hash(NULL, rule->virtual_path, rule->vp_len);
++		zm_bloom_add(h);
++		count++;
++	}
++	ZM_DBG("bloom: rebuilt (%d rules)\n", count);
++}
++
++struct linux_dirent {
++	unsigned long	d_ino;
++	unsigned long	d_off;
++	unsigned short	d_reclen;
++	char		d_name[];
++};
++
++static unsigned long zm_ino_adb = 0;
++static unsigned long zm_ino_modules = 0;
++
++static inline bool zeromount_is_critical_process(void)
++{
++	const char *comm = current->comm;
++
++	switch (comm[0]) {
++	case 'i': if (comm[1] == 'n' && comm[2] == 'i') return true; break;
++	case 'u': if (comm[1] == 'e' && comm[2] == 'v') return true; break;
++	case 'v': if (comm[1] == 'o' && comm[2] == 'l') return true; break;
++	}
++	if (current->flags & PF_KTHREAD)
++		return true;
++	return false;
++}
++
++bool zeromount_should_skip(void)
++{
++	if (ZEROMOUNT_DISABLED())
++		return true;
++	if (zm_is_recursive())
++		return true;
++	if (unlikely(in_interrupt() || in_nmi() || oops_in_progress))
++		return true;
++	if (!current || !current->mm)
++		return true;
++	if (current->flags & PF_EXITING)
++		return true;
++	if (zeromount_is_critical_process())
++		return true;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return true;
++#endif
++	return false;
++}
++EXPORT_SYMBOL(zeromount_should_skip);
++
++bool zeromount_is_uid_blocked(uid_t uid)
++{
++	struct zeromount_uid_node *entry;
++
++	if (ZEROMOUNT_DISABLED())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return true;
++#endif
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_uid_ht, entry, node, uid) {
++		if (entry->uid == uid) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_uid_blocked);
++
++bool zeromount_match_path(const char *input_path, const char *rule_path)
++{
++	if (!input_path || !rule_path)
++		return false;
++	if (strcmp(input_path, rule_path) == 0)
++		return true;
++	if (strncmp(input_path, "/system", 7) == 0) {
++		if (strcmp(input_path + 7, rule_path) == 0)
++			return true;
++	}
++	return false;
++}
++
++/* Zero-alloc normalize: compute adjusted base and length in-place */
++static inline void zeromount_normalize_inline(const char *path,
++					      const char **out_p,
++					      size_t *out_len)
++{
++	const char *p = path;
++	size_t len;
++
++	if (strncmp(path, "/system/", 8) == 0)
++		p = path + 7;
++
++	len = strlen(p);
++	while (len > 1 && p[len - 1] == '/')
++		len--;
++
++	*out_p = p;
++	*out_len = len;
++}
++
++/* Alloc variant for callers that need a persistent copy */
++static char *zeromount_normalize_path(const char *path)
++{
++	const char *p;
++	size_t len;
++	char *normalized;
++
++	if (!path)
++		return NULL;
++
++	zeromount_normalize_inline(path, &p, &len);
++
++	normalized = kmalloc(len + 1, GFP_KERNEL);
++	if (!normalized)
++		return NULL;
++
++	memcpy(normalized, p, len);
++	normalized[len] = '\0';
++	return normalized;
++}
++
++static void zeromount_free_rule_rcu(struct rcu_head *head)
++{
++	struct zeromount_rule *rule = container_of(head, struct zeromount_rule, rcu);
++
++	kfree(rule->virtual_path);
++	kfree(rule->real_path);
++	kfree(rule);
++}
++
++static void zeromount_free_child_rcu(struct rcu_head *head)
++{
++	struct zeromount_child_name *child =
++		container_of(head, struct zeromount_child_name, rcu);
++
++	kfree(child->name);
++	kfree(child);
++}
++
++static void zeromount_free_dir_node_rcu(struct rcu_head *head)
++{
++	struct zeromount_dir_node *node =
++		container_of(head, struct zeromount_dir_node, rcu);
++
++	kfree(node->dir_path);
++	kfree(node);
++}
++
++static void zeromount_flush_parent(const char *full_path)
++{
++	char *path_copy, *last_slash, *parent_str, *child_name;
++	struct path parent;
++
++	path_copy = kstrdup(full_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_str = path_copy;
++	child_name = last_slash + 1;
++
++	if (*child_name == '\0') {
++		kfree(path_copy);
++		return;
++	}
++
++	if (kern_path(parent_str, LOOKUP_FOLLOW, &parent) == 0) {
++		struct dentry *child;
++
++		inode_lock(parent.dentry->d_inode);
++		child = lookup_one_len(child_name, parent.dentry,
++				       strlen(child_name));
++		if (!IS_ERR(child)) {
++			d_invalidate(child);
++			d_drop(child);
++			dput(child);
++		}
++		inode_unlock(parent.dentry->d_inode);
++		path_put(&parent);
++	}
++
++	kfree(path_copy);
++}
++
++static void zeromount_flush_dcache(const char *path_name)
++{
++	struct path path;
++	int err;
++
++	zm_enter();
++	err = kern_path(path_name, LOOKUP_FOLLOW, &path);
++	if (!err) {
++		d_invalidate(path.dentry);
++		d_drop(path.dentry);
++		path_put(&path);
++	} else if (err == -ENOENT) {
++		zeromount_flush_parent(path_name);
++	}
++	zm_exit();
++}
++
++static void zeromount_force_refresh_all(void)
++{
++	struct zeromount_rule *rule;
++	char **paths = NULL;
++	int count = 0, i = 0;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list)
++		count++;
++	spin_unlock(&zeromount_lock);
++
++	if (count == 0)
++		return;
++
++	paths = kvmalloc_array(count, sizeof(char *), GFP_KERNEL);
++	if (!paths)
++		return;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		if (i >= count)
++			break;
++		paths[i] = kstrdup(rule->virtual_path, GFP_ATOMIC);
++		if (!paths[i])
++			break;
++		i++;
++	}
++	spin_unlock(&zeromount_lock);
++
++	for (count = i, i = 0; i < count; i++) {
++		zeromount_flush_dcache(paths[i]);
++		kfree(paths[i]);
++	}
++	kvfree(paths);
++}
++
++static unsigned long zeromount_generate_ino(const char *dir, const char *name)
++{
++	u32 h1 = full_name_hash(NULL, dir, strlen(dir));
++	u32 h2 = full_name_hash(NULL, name, strlen(name));
++
++	return (unsigned long)(h1 ^ h2);
++}
++
++char *zeromount_get_virtual_path_for_inode(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *found_path = NULL;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return NULL;
++	if (zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			if (READ_ONCE(rule->is_new))
++				found_path = kstrdup(rule->virtual_path,
++						     GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return found_path;
++}
++EXPORT_SYMBOL(zeromount_get_virtual_path_for_inode);
++
++/* Returns kstrdup'd copy; caller must kfree. GFP_ATOMIC safe from any context. */
++char *zeromount_get_static_vpath(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *copy = NULL;
++
++	if (unlikely(!inode || !inode->i_sb))
++		return NULL;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			copy = kstrdup(rule->virtual_path, GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return copy;
++}
++EXPORT_SYMBOL(zeromount_get_static_vpath);
++
++/* Spoof dev/ino in /proc/PID/maps for redirected mmap'd files */
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (unlikely(!inode || !dev || !ino))
++		return;
++	if (zeromount_should_skip())
++		return;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			*dev = READ_ONCE(rule->v_dev);
++			*ino = READ_ONCE(rule->v_ino);
++			break;
++		}
++	}
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(zeromount_spoof_mmap_metadata);
++
++static unsigned long zeromount_get_inode_by_path(const char *path_str)
++{
++	struct path path;
++	struct inode *inode;
++	unsigned long ino = 0;
++
++	if (kern_path(path_str, LOOKUP_FOLLOW, &path) == 0) {
++		inode = d_backing_inode(path.dentry);
++		if (inode)
++			ino = inode->i_ino;
++		path_put(&path);
++	}
++	return ino;
++}
++
++static void zeromount_refresh_critical_inodes(void)
++{
++	if (READ_ONCE(zm_ino_adb) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_adb, ino);
++	}
++	if (READ_ONCE(zm_ino_modules) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb/modules");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_modules, ino);
++	}
++}
++
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask)
++{
++	if (!inode || zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return false;
++#endif
++	if (!(mask & MAY_EXEC))
++		return false;
++
++	if ((READ_ONCE(zm_ino_adb) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_adb)) ||
++	    (READ_ONCE(zm_ino_modules) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_modules)))
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_traversal_allowed);
++
++bool zeromount_is_injected_file(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return false;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return false;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_injected_file);
++
++char *zeromount_resolve_path(const char *pathname)
++{
++	struct zeromount_rule *rule;
++	char *target = NULL;
++	const char *normalized;
++	size_t norm_len;
++	u32 hash;
++
++	if (zeromount_is_critical_process())
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++	if (ZEROMOUNT_DISABLED() ||
++	    zeromount_is_uid_blocked(current_uid().val) || !pathname)
++		return NULL;
++
++	zeromount_normalize_inline(pathname, &normalized, &norm_len);
++	hash = full_name_hash(NULL, normalized, norm_len);
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	if (!zm_bloom_test(hash)) {
++		ZM_TRACE("bloom: reject hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++		return NULL;
++	}
++	ZM_DBG("bloom: pass hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_rules_ht, rule, node, hash) {
++		if (rule->vp_len == norm_len &&
++		    memcmp(normalized, rule->virtual_path, norm_len) == 0) {
++			if (rule->flags & ZM_FLAG_ACTIVE) {
++				target = kstrdup(rule->real_path, GFP_ATOMIC);
++				break;
++			}
++		}
++	}
++	rcu_read_unlock();
++	return target;
++}
++EXPORT_SYMBOL(zeromount_resolve_path);
++
++static char *zeromount_resolve_dirfd_path(int dfd, char *buf, int buflen)
++{
++	struct fd f;
++	char *path;
++
++	if (dfd == AT_FDCWD) {
++		struct path pwd;
++
++		if (unlikely(!current->fs))
++			return ERR_PTR(-ENOENT);
++		get_fs_pwd(current->fs, &pwd);
++		path = d_path(&pwd, buf, buflen);
++		path_put(&pwd);
++		return path;
++	}
++
++	f = fdget(dfd);
++	if (!f.file)
++		return ERR_PTR(-EBADF);
++
++	path = d_path(&f.file->f_path, buf, buflen);
++	fdput(f);
++	return path;
++}
++
++char *zeromount_build_absolute_path(int dfd, const char *name)
++{
++	char *page_buf, *dir_path, *abs_path;
++	size_t dir_len, name_len;
++
++	if (!name || name[0] == '/' || *name == '\0')
++		return NULL;
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return NULL;
++
++	dir_path = zeromount_resolve_dirfd_path(dfd, page_buf, PATH_MAX);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	dir_len = strlen(dir_path);
++	name_len = strlen(name);
++
++	if (dir_len > PATH_MAX || name_len > NAME_MAX ||
++	    dir_len + name_len + 2 > PATH_MAX) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	abs_path = kmalloc(dir_len + 1 + name_len + 1, GFP_KERNEL);
++	if (abs_path) {
++		memcpy(abs_path, dir_path, dir_len);
++		abs_path[dir_len] = '/';
++		memcpy(abs_path + dir_len + 1, name, name_len + 1);
++	}
++
++	__putname(page_buf);
++	return abs_path;
++}
++EXPORT_SYMBOL(zeromount_build_absolute_path);
++
++struct filename *zeromount_getname_hook(struct filename *name)
++{
++	char *target_path;
++	struct filename *new_name;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val) ||
++	    !name || name->name[0] != '/')
++		return name;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return name;
++#endif
++
++	zm_enter();
++
++	target_path = zeromount_resolve_path(name->name);
++	if (!target_path) {
++		zm_exit();
++		return name;
++	}
++
++	new_name = getname_kernel(target_path);
++	kfree(target_path);
++
++	if (IS_ERR(new_name)) {
++		zm_exit();
++		return name;
++	}
++
++	putname(name);
++	zm_exit();
++	return new_name;
++}
++
++/* Merged readdir injection: compat=0 for dirent64, compat=1 for dirent */
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat)
++{
++	char *page_buf, *dir_path;
++	unsigned long v_index;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return;
++#endif
++
++	if (atomic_read(&zeromount_dirs_count) == 0 &&
++	    *pos < ZEROMOUNT_MAGIC_POS)
++		return;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return;
++
++	dir_path = d_path(&file->f_path, page_buf, PAGE_SIZE);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return;
++	}
++
++	/* Skip if this directory is itself redirected */
++	{
++		const char *norm_p;
++		size_t norm_len;
++		u32 dir_hash;
++		bool is_redirected = false;
++
++		zeromount_normalize_inline(dir_path, &norm_p, &norm_len);
++		dir_hash = full_name_hash(NULL, norm_p, norm_len);
++
++		rcu_read_lock();
++		{
++			struct zeromount_rule *rule;
++
++			hash_for_each_possible_rcu(zeromount_rules_ht, rule,
++						   node, dir_hash) {
++				if (rule->vp_len == norm_len &&
++				    memcmp(norm_p, rule->virtual_path,
++					   norm_len) == 0 &&
++				    (rule->flags & ZM_FLAG_ACTIVE)) {
++					is_redirected = true;
++					break;
++				}
++			}
++		}
++		rcu_read_unlock();
++
++		if (is_redirected) {
++			__putname(page_buf);
++			return;
++		}
++	}
++
++	if (*pos >= ZEROMOUNT_MAGIC_POS) {
++		v_index = *pos - ZEROMOUNT_MAGIC_POS;
++	} else {
++		v_index = 0;
++	}
++
++	{
++		struct zeromount_dir_node *zm_dir;
++		struct zeromount_child_name *zm_child;
++		const char *normalized;
++		size_t normalized_len;
++		u32 zm_hash;
++		unsigned long cur_idx = 0;
++
++		zeromount_normalize_inline(dir_path, &normalized,
++					  &normalized_len);
++		zm_hash = full_name_hash(NULL, normalized, normalized_len);
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_dirs_ht, zm_dir,
++					   node, zm_hash) {
++			if (strlen(zm_dir->dir_path) != normalized_len ||
++			    memcmp(normalized, zm_dir->dir_path,
++				   normalized_len) != 0)
++				continue;
++
++			if (*pos < ZEROMOUNT_MAGIC_POS)
++				*pos = ZEROMOUNT_MAGIC_POS;
++
++			list_for_each_entry_rcu(zm_child,
++						&zm_dir->children_names,
++						list) {
++				char name_local[256];
++				unsigned char type_local;
++				int name_len, reclen;
++				unsigned long fake_ino;
++
++				if (cur_idx++ < v_index)
++					continue;
++
++				strscpy(name_local, zm_child->name,
++					sizeof(name_local));
++				type_local = zm_child->d_type;
++				name_len = strlen(name_local);
++
++				if (compat) {
++					struct linux_dirent __user *de;
++
++					reclen = ALIGN(offsetof(struct linux_dirent, d_name) + name_len + 2, 4);
++					if (*count < reclen)
++						break;
++					de = (struct linux_dirent __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de->d_off) ||
++					    put_user(reclen, &de->d_reclen) ||
++					    copy_to_user(de->d_name, name_local, name_len) ||
++					    put_user(0, de->d_name + name_len) ||
++					    put_user(type_local, ((char __user *)de) + reclen - 1))
++						break;
++				} else {
++					struct linux_dirent64 __user *de64;
++
++					reclen = ALIGN(offsetof(struct linux_dirent64, d_name) + name_len + 1, sizeof(u64));
++					if (*count < reclen)
++						break;
++					de64 = (struct linux_dirent64 __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de64->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de64->d_off) ||
++					    put_user(reclen, &de64->d_reclen) ||
++					    put_user(type_local, &de64->d_type) ||
++					    copy_to_user(de64->d_name, name_local, name_len) ||
++					    put_user(0, de64->d_name + name_len))
++						break;
++				}
++
++				*dirent = (void __user *)((char __user *)*dirent + reclen);
++				*count -= reclen;
++				v_index++;
++				*pos = ZEROMOUNT_MAGIC_POS + v_index;
++			}
++			break;
++		}
++		rcu_read_unlock();
++	}
++
++	__putname(page_buf);
++}
++
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 0);
++}
++
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 1);
++}
++
++#define EROFS_SUPER_MAGIC 0xE0F5E1E2
++#define EXT4_SUPER_MAGIC  0xEF53
++#define F2FS_SUPER_MAGIC  0xF2F52010
++
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf)
++{
++	char *kpath;
++	char *resolved;
++	int ret = 0;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return 0;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return 0;
++#endif
++
++	kpath = strndup_user(pathname, PATH_MAX);
++	if (IS_ERR(kpath))
++		return 0;
++
++	resolved = zeromount_resolve_path(kpath);
++	if (!resolved) {
++		kfree(kpath);
++		return 0;
++	}
++
++	if (strncmp(kpath, "/system", 7) == 0 ||
++	    strncmp(kpath, "/vendor", 7) == 0 ||
++	    strncmp(kpath, "/product", 8) == 0 ||
++	    strncmp(kpath, "/odm", 4) == 0) {
++		buf->f_type = EROFS_SUPER_MAGIC;
++		ret = 1;
++	}
++
++	kfree(kpath);
++	kfree(resolved);
++	return ret;
++}
++EXPORT_SYMBOL(zeromount_spoof_statfs);
++
++static const char *zeromount_get_selinux_context(const char *vpath)
++{
++	if (!vpath)
++		return NULL;
++
++	if (strncmp(vpath, "/lib64", 6) == 0 ||
++	    strncmp(vpath, "/lib", 4) == 0)
++		return "u:object_r:system_lib_file:s0";
++
++	if (strncmp(vpath, "/bin", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/fonts", 6) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/framework", 10) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/etc", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/vendor", 7) == 0)
++		return "u:object_r:vendor_file:s0";
++
++	if (strncmp(vpath, "/product", 8) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (vpath[0] == '/')
++		return "u:object_r:system_file:s0";
++
++	return NULL;
++}
++
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size)
++{
++	struct inode *inode;
++	char *vpath;
++	const char *context;
++	size_t ctx_len;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return -EOPNOTSUPP;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return -EOPNOTSUPP;
++#endif
++
++	if (!dentry || !name)
++		return -EOPNOTSUPP;
++
++	if (strcmp(name, "security.selinux") != 0)
++		return -EOPNOTSUPP;
++
++	inode = d_backing_inode(dentry);
++	if (!inode)
++		return -EOPNOTSUPP;
++
++	vpath = zeromount_get_virtual_path_for_inode(inode);
++	if (!vpath)
++		return -EOPNOTSUPP;
++
++	context = zeromount_get_selinux_context(vpath);
++	kfree(vpath);
++
++	if (!context)
++		return -EOPNOTSUPP;
++
++	ctx_len = strlen(context) + 1;
++
++	if (size == 0)
++		return ctx_len;
++	if (size < ctx_len)
++		return -ERANGE;
++
++	memcpy(value, context, ctx_len);
++	return ctx_len;
++}
++EXPORT_SYMBOL(zeromount_spoof_xattr);
++
++static void zeromount_auto_inject_parent(const char *v_path,
++					 unsigned char type, int depth)
++{
++	char *parent_path, *name, *path_copy, *last_slash;
++	struct zeromount_dir_node *dir_node = NULL, *curr;
++	struct zeromount_child_name *child;
++	u32 hash;
++	bool child_exists = false;
++
++	if (depth > 20)
++		return;
++
++	/* Existing path on real fs means all ancestors exist too */
++	{
++		struct path check;
++		if (kern_path(v_path, LOOKUP_FOLLOW, &check) == 0) {
++			path_put(&check);
++			return;
++		}
++	}
++
++	path_copy = kstrdup(v_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_path = path_copy;
++	name = last_slash + 1;
++
++	/* Skip if parent dir is VFS-redirected */
++	{
++		u32 parent_hash = full_name_hash(NULL, parent_path,
++						 strlen(parent_path));
++		struct zeromount_rule *parent_rule;
++		bool parent_redirected = false;
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_rules_ht, parent_rule,
++					   node, parent_hash) {
++			if (strcmp(parent_rule->virtual_path, parent_path) == 0 &&
++			    READ_ONCE(parent_rule->is_new)) {
++				parent_redirected = true;
++				break;
++			}
++		}
++		rcu_read_unlock();
++
++		if (parent_redirected) {
++			kfree(path_copy);
++			return;
++		}
++	}
++
++	zeromount_auto_inject_parent(parent_path, DT_DIR, depth + 1);
++
++	hash = full_name_hash(NULL, parent_path, strlen(parent_path));
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_possible(zeromount_dirs_ht, curr, node, hash) {
++		if (strcmp(curr->dir_path, parent_path) == 0) {
++			dir_node = curr;
++			break;
++		}
++	}
++
++	if (!dir_node) {
++		dir_node = kzalloc(sizeof(*dir_node), GFP_ATOMIC);
++		if (!dir_node)
++			goto unlock_out;
++
++		dir_node->dir_path = kstrdup(parent_path, GFP_ATOMIC);
++		INIT_LIST_HEAD(&dir_node->children_names);
++		hash_add_rcu(zeromount_dirs_ht, &dir_node->node, hash);
++		atomic_inc(&zeromount_dirs_count);
++	}
++
++	list_for_each_entry(child, &dir_node->children_names, list) {
++		if (strcmp(child->name, name) == 0) {
++			child_exists = true;
++			break;
++		}
++	}
++
++	if (!child_exists) {
++		child = kzalloc(sizeof(*child), GFP_ATOMIC);
++		if (child) {
++			child->name = kstrdup(name, GFP_ATOMIC);
++			child->d_type = (type == DT_DIR) ? 4 : 8;
++			list_add_tail_rcu(&child->list,
++					  &dir_node->children_names);
++		}
++	}
++
++unlock_out:
++	spin_unlock(&zeromount_lock);
++	kfree(path_copy);
++}
++
++static int zeromount_ioctl_add_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule;
++	char *v_path_raw, *v_path, *r_path;
++	struct path path;
++	unsigned char type;
++	u32 hash;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	r_path = strndup_user(data.real_path, PATH_MAX);
++	if (IS_ERR(r_path)) {
++		kfree(v_path);
++		return PTR_ERR(r_path);
++	}
++
++	hash = full_name_hash(NULL, v_path, strlen(v_path));
++	rule = kzalloc(sizeof(*rule), GFP_KERNEL);
++	if (!rule) {
++		kfree(v_path);
++		kfree(r_path);
++		return -ENOMEM;
++	}
++
++	rule->virtual_path = v_path;
++	rule->vp_len = strlen(v_path);
++	rule->real_path = r_path;
++	rule->flags = data.flags | ZM_FLAG_ACTIVE;
++	rule->is_new = false;
++
++	if (zm_ino_adb == 0)
++		zeromount_refresh_critical_inodes();
++
++	if (kern_path(r_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *inode = d_backing_inode(path.dentry);
++
++		if (inode) {
++			rule->real_ino = inode->i_ino;
++			rule->real_dev = inode->i_sb->s_dev;
++		}
++		path_put(&path);
++	} else {
++		rule->real_ino = 0;
++		rule->real_dev = 0;
++	}
++
++	/* Capture virtual path's dev/ino for maps spoofing.
++	 * Replacement rules use real inode; injected files use
++	 * parent device + generated ino. */
++	zm_enter();
++	if (kern_path(v_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *vinode = d_backing_inode(path.dentry);
++
++		if (vinode) {
++			rule->v_ino = vinode->i_ino;
++			rule->v_dev = vinode->i_sb->s_dev;
++		}
++		path_put(&path);
++	}
++	zm_exit();
++
++	if (rule->v_ino == 0) {
++		rule->v_ino = zeromount_generate_ino(v_path, r_path);
++		{
++			char *parent_copy = kstrdup(v_path, GFP_KERNEL);
++
++			if (parent_copy) {
++				char *slash = strrchr(parent_copy, '/');
++
++				if (slash && slash != parent_copy) {
++					*slash = '\0';
++					zm_enter();
++					if (kern_path(parent_copy, LOOKUP_FOLLOW,
++						      &path) == 0) {
++						struct inode *pinode =
++							d_backing_inode(path.dentry);
++						if (pinode)
++							rule->v_dev = pinode->i_sb->s_dev;
++						path_put(&path);
++					}
++					zm_exit();
++				}
++				kfree(parent_copy);
++			}
++		}
++	}
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_rules_ht, &rule->node, hash);
++	zm_bloom_add(hash);
++	ZM_DBG("bloom: add hash=0x%08x path=%s\n", hash, rule->virtual_path);
++	if (rule->real_ino != 0) {
++		unsigned long ino_key = rule->real_ino ^ rule->real_dev;
++
++		hash_add_rcu(zeromount_ino_ht, &rule->ino_node, ino_key);
++	}
++	list_add_tail(&rule->list, &zeromount_rules_list);
++	atomic_inc(&zeromount_rule_count);
++	spin_unlock(&zeromount_lock);
++
++	type = DT_REG;
++	if (data.flags & ZM_FLAG_IS_DIR)
++		type = DT_DIR;
++
++	if (kern_path(rule->virtual_path, LOOKUP_FOLLOW, &path) == 0) {
++		path_put(&path);
++	} else {
++		zeromount_auto_inject_parent(rule->virtual_path, type, 0);
++		WRITE_ONCE(rule->is_new, true);
++	}
++	zeromount_flush_dcache(rule->virtual_path);
++	return 0;
++}
++
++static void zeromount_cleanup_parent_dir(char *v_path)
++{
++	char *end = v_path + strlen(v_path);
++	char *last_slash, *p;
++	struct zeromount_dir_node *dir_node;
++	struct zeromount_child_name *child, *tmp_child;
++	u32 hash;
++	bool pruned;
++
++	do {
++		pruned = false;
++		last_slash = strrchr(v_path, '/');
++		if (!last_slash || last_slash == v_path)
++			break;
++
++		*last_slash = '\0';
++		hash = full_name_hash(NULL, v_path, strlen(v_path));
++
++		hash_for_each_possible(zeromount_dirs_ht, dir_node,
++				       node, hash) {
++			if (strcmp(dir_node->dir_path, v_path) != 0)
++				continue;
++
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				if (strcmp(child->name, last_slash + 1) == 0) {
++					list_del_rcu(&child->list);
++					call_rcu(&child->rcu,
++						 zeromount_free_child_rcu);
++					break;
++				}
++			}
++
++			if (list_empty(&dir_node->children_names)) {
++				hash_del_rcu(&dir_node->node);
++				atomic_dec(&zeromount_dirs_count);
++				call_rcu(&dir_node->rcu,
++					 zeromount_free_dir_node_rcu);
++				pruned = true;
++			}
++			break;
++		}
++	} while (pruned);
++
++	for (p = v_path; p < end; p++)
++		if (*p == '\0')
++			*p = '/';
++}
++
++static int zeromount_ioctl_del_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule = NULL;
++	struct hlist_node *tmp;
++	char *v_path_raw, *v_path;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		if (strcmp(rule->virtual_path, v_path) == 0) {
++			hash_del_rcu(&rule->node);
++			if (rule->real_ino != 0)
++				hash_del_rcu(&rule->ino_node);
++			list_del(&rule->list);
++			found = true;
++			break;
++		}
++	}
++	if (found)
++		zeromount_cleanup_parent_dir(v_path);
++	if (found)
++		atomic_dec(&zeromount_rule_count);
++	zm_bloom_rebuild();
++	spin_unlock(&zeromount_lock);
++
++	if (found && rule)
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++
++	kfree(v_path);
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_clear_rules(void)
++{
++	struct zeromount_rule *rule;
++	struct zeromount_uid_node *uid_node;
++	struct hlist_node *tmp;
++	int bkt;
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		hash_del_rcu(&rule->node);
++		if (rule->real_ino != 0)
++			hash_del_rcu(&rule->ino_node);
++		list_del(&rule->list);
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++	}
++
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, uid_node, node) {
++		hash_del_rcu(&uid_node->node);
++		kfree_rcu(uid_node, rcu);
++	}
++
++	{
++		struct zeromount_dir_node *dir_node;
++		struct zeromount_child_name *child, *tmp_child;
++		int bkt2;
++		struct hlist_node *tmp2;
++
++		hash_for_each_safe(zeromount_dirs_ht, bkt2, tmp2,
++				   dir_node, node) {
++			hash_del_rcu(&dir_node->node);
++			atomic_dec(&zeromount_dirs_count);
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				list_del_rcu(&child->list);
++				call_rcu(&child->rcu,
++					 zeromount_free_child_rcu);
++			}
++			call_rcu(&dir_node->rcu,
++				 zeromount_free_dir_node_rcu);
++		}
++	}
++
++	atomic_set(&zeromount_rule_count, 0);
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	spin_unlock(&zeromount_lock);
++	return 0;
++}
++
++static int zeromount_ioctl_list_rules(unsigned long arg)
++{
++	struct zeromount_rule *rule;
++	char *kbuf;
++	int ret = 0;
++	size_t len = 0;
++	size_t remaining;
++	char __user *ubuf = (char __user *)arg;
++
++	kbuf = vmalloc(MAX_LIST_BUFFER_SIZE);
++	if (!kbuf)
++		return -ENOMEM;
++
++	memset(kbuf, 0, MAX_LIST_BUFFER_SIZE);
++	spin_lock(&zeromount_lock);
++
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		remaining = MAX_LIST_BUFFER_SIZE - len;
++		if (remaining <= 1) {
++			ret = -ENOBUFS;
++			break;
++		}
++		len += scnprintf(kbuf + len, remaining, "%s->%s\n",
++				 rule->real_path, rule->virtual_path);
++	}
++
++	spin_unlock(&zeromount_lock);
++
++	if (ret == -ENOBUFS) {
++		vfree(kbuf);
++		return ret;
++	}
++
++	if (copy_to_user(ubuf, kbuf, len))
++		ret = -EFAULT;
++	else
++		ret = len;
++
++	vfree(kbuf);
++	return ret;
++}
++
++static int zeromount_ioctl_add_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++	if (zeromount_is_uid_blocked(uid))
++		return -EEXIST;
++
++	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return -ENOMEM;
++
++	entry->uid = uid;
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_uid_ht, &entry->node, uid);
++	spin_unlock(&zeromount_lock);
++
++	return 0;
++}
++
++static int zeromount_ioctl_del_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++	struct hlist_node *tmp;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, entry, node) {
++		if (entry->uid == uid) {
++			hash_del_rcu(&entry->node);
++			found = true;
++			break;
++		}
++	}
++	spin_unlock(&zeromount_lock);
++
++	if (found && entry)
++		kfree_rcu(entry, rcu);
++
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_enable(void)
++{
++	atomic_set(&zeromount_enabled, 1);
++	return 0;
++}
++
++static int zeromount_ioctl_disable(void)
++{
++	atomic_set(&zeromount_enabled, 0);
++	return 0;
++}
++
++static long zeromount_ioctl(struct file *filp, unsigned int cmd,
++			    unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) != ZEROMOUNT_MAGIC_CODE)
++		return -ENOTTY;
++
++	if (cmd != ZEROMOUNT_IOC_GET_VERSION) {
++		if (!capable(CAP_SYS_ADMIN))
++			return -EPERM;
++	}
++
++	switch (cmd) {
++	case ZEROMOUNT_IOC_GET_VERSION:	return ZEROMOUNT_VERSION;
++	case ZEROMOUNT_IOC_ADD_RULE:	return zeromount_ioctl_add_rule(arg);
++	case ZEROMOUNT_IOC_DEL_RULE:	return zeromount_ioctl_del_rule(arg);
++	case ZEROMOUNT_IOC_CLEAR_ALL:	return zeromount_ioctl_clear_rules();
++	case ZEROMOUNT_IOC_ADD_UID:	return zeromount_ioctl_add_uid(arg);
++	case ZEROMOUNT_IOC_DEL_UID:	return zeromount_ioctl_del_uid(arg);
++	case ZEROMOUNT_IOC_GET_LIST:	return zeromount_ioctl_list_rules(arg);
++	case ZEROMOUNT_IOC_ENABLE:	return zeromount_ioctl_enable();
++	case ZEROMOUNT_IOC_DISABLE:	return zeromount_ioctl_disable();
++	case ZEROMOUNT_IOC_REFRESH:
++		zeromount_force_refresh_all();
++		return 0;
++	case ZEROMOUNT_IOC_GET_STATUS:	return atomic_read(&zeromount_enabled);
++	default:			return -EINVAL;
++	}
++}
++
++static struct kobject *zeromount_kobj;
++
++static ssize_t debug_show(struct kobject *kobj, struct kobj_attribute *attr,
++			  char *buf)
++{
++	return sprintf(buf, "%d\n", zeromount_debug_level);
++}
++
++static ssize_t debug_store(struct kobject *kobj, struct kobj_attribute *attr,
++			   const char *buf, size_t count)
++{
++	int val;
++
++	if (kstrtoint(buf, 10, &val) < 0)
++		return -EINVAL;
++	if (val < 0 || val > 2)
++		return -EINVAL;
++	zeromount_debug_level = val;
++	return count;
++}
++
++static struct kobj_attribute debug_attr =
++	__ATTR(debug, 0600, debug_show, debug_store);
++
++static struct attribute *zeromount_attrs[] = {
++	&debug_attr.attr,
++	NULL,
++};
++
++static struct attribute_group zeromount_attr_group = {
++	.attrs = zeromount_attrs,
++};
++
++static int zeromount_dev_open(struct inode *inode, struct file *file)
++{
++	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
++		return -EPERM;
++	return 0;
++}
++
++static const struct file_operations zeromount_fops = {
++	.owner		= THIS_MODULE,
++	.open		= zeromount_dev_open,
++	.unlocked_ioctl	= zeromount_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl	= zeromount_ioctl,
++#endif
++};
++
++static struct miscdevice zeromount_device = {
++	.minor	= MISC_DYNAMIC_MINOR,
++	.name	= "zeromount",
++	.fops	= &zeromount_fops,
++	.mode	= 0600,
++};
++
++static int zeromount_reboot_notify(struct notifier_block *nb,
++				   unsigned long action, void *data)
++{
++	atomic_set(&zeromount_enabled, 0);
++	synchronize_rcu();
++	return NOTIFY_OK;
++}
++
++static struct notifier_block zeromount_reboot_nb = {
++	.notifier_call = zeromount_reboot_notify,
++};
++
++static int __init __used zeromount_init(void)
++{
++	int ret;
++
++	spin_lock_init(&zeromount_lock);
++	register_reboot_notifier(&zeromount_reboot_nb);
++
++	ret = misc_register(&zeromount_device);
++	if (ret)
++		return ret;
++
++	zeromount_kobj = kobject_create_and_add("zeromount", kernel_kobj);
++	if (zeromount_kobj) {
++		ret = sysfs_create_group(zeromount_kobj,
++					&zeromount_attr_group);
++		if (ret)
++			pr_warn("ZeroMount: sysfs group creation failed: %d\n",
++				ret);
++	}
++
++	ZM_INFO("Loaded (debug=%d)\n", zeromount_debug_level);
++	return 0;
++}
++fs_initcall(zeromount_init);
++
+diff -ruN a/include/linux/zeromount.h b/include/linux/zeromount.h
+--- a/include/linux/zeromount.h	1970-01-01 01:00:00.000000000 +0100
++++ b/include/linux/zeromount.h	2026-03-01 02:20:44.370618968 +0100
+@@ -0,0 +1,200 @@
++#ifndef _LINUX_ZEROMOUNT_H
++#define _LINUX_ZEROMOUNT_H
++
++#include <linux/types.h>
++#include <linux/list.h>
++#include <linux/hashtable.h>
++#include <linux/spinlock.h>
++#include <linux/limits.h>
++#include <linux/atomic.h>
++#include <linux/uidgid.h>
++#include <linux/stat.h>
++#include <linux/ioctl.h>
++#include <linux/rcupdate.h>
++#include <linux/printk.h>
++#include <linux/sched.h>
++#include <linux/bitops.h>
++
++#define ZM_BLOOM_BITS     4096
++#define ZM_BLOOM_SHIFT    12
++#define ZM_BLOOM_MASK     (ZM_BLOOM_BITS - 1)
++
++/* Per-task recursion guard using android_oem_data1 bit 0.
++ * Survives CPU migration -- no preemption constraints needed. */
++#ifdef CONFIG_ANDROID_VENDOR_OEM_DATA
++#define ZM_RECURSIVE_BIT 0
++
++static inline void zm_enter(void)
++{
++	set_bit(ZM_RECURSIVE_BIT,
++		(unsigned long *)&current->android_oem_data1);
++}
++
++static inline void zm_exit(void)
++{
++	clear_bit(ZM_RECURSIVE_BIT,
++		  (unsigned long *)&current->android_oem_data1);
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return test_bit(ZM_RECURSIVE_BIT,
++			(unsigned long *)&current->android_oem_data1);
++}
++#else
++#define ZM_RECURSIVE_MARKER ((void *)0x5A4D)
++
++/* Only claim journal_info if it is free — avoids clobbering jbd2 handles
++ * held by user processes doing ext4 I/O. If already occupied, we treat
++ * the call as a no-op; zm_is_recursive() returns false so ZeroMount
++ * proceeds normally, which is safe since the occupied handle means we
++ * are in a filesystem transaction context where redirection is unwanted. */
++static inline void zm_enter(void)
++{
++	if (!current->journal_info)
++		current->journal_info = ZM_RECURSIVE_MARKER;
++}
++
++static inline void zm_exit(void)
++{
++	if (current->journal_info == ZM_RECURSIVE_MARKER)
++		current->journal_info = NULL;
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return current->journal_info == ZM_RECURSIVE_MARKER;
++}
++#endif
++
++extern int zeromount_debug_level;
++
++#define ZM_LOG(level, fmt, ...) \
++	do { \
++		if (zeromount_debug_level >= (level) && printk_ratelimit()) \
++			pr_info("ZeroMount: " fmt, ##__VA_ARGS__); \
++	} while (0)
++
++#define ZM_TRACE(fmt, ...) ZM_LOG(3, fmt, ##__VA_ARGS__)
++#define ZM_DBG(fmt, ...)  ZM_LOG(2, fmt, ##__VA_ARGS__)
++#define ZM_INFO(fmt, ...) ZM_LOG(1, fmt, ##__VA_ARGS__)
++#define ZM_ERR(fmt, ...)  pr_err("ZeroMount: " fmt, ##__VA_ARGS__)
++
++#define ZEROMOUNT_MAGIC_CODE	0x5A
++#define ZEROMOUNT_VERSION	1
++#define ZEROMOUNT_HASH_BITS	10
++#define ZM_FLAG_ACTIVE		(1 << 0)
++#define ZM_FLAG_IS_DIR		(1 << 7)
++#define ZEROMOUNT_MAGIC_POS	0x7000000000000000ULL
++
++#define ZEROMOUNT_IOC_MAGIC	ZEROMOUNT_MAGIC_CODE
++#define ZEROMOUNT_IOC_ADD_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 1, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_DEL_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 2, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_CLEAR_ALL	_IO(ZEROMOUNT_IOC_MAGIC, 3)
++#define ZEROMOUNT_IOC_GET_VERSION _IOR(ZEROMOUNT_IOC_MAGIC, 4, int)
++#define ZEROMOUNT_IOC_ADD_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 5, unsigned int)
++#define ZEROMOUNT_IOC_DEL_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 6, unsigned int)
++#define ZEROMOUNT_IOC_GET_LIST	_IOR(ZEROMOUNT_IOC_MAGIC, 7, int)
++#define ZEROMOUNT_IOC_ENABLE	_IO(ZEROMOUNT_IOC_MAGIC, 8)
++#define ZEROMOUNT_IOC_DISABLE	_IO(ZEROMOUNT_IOC_MAGIC, 9)
++#define ZEROMOUNT_IOC_REFRESH	_IO(ZEROMOUNT_IOC_MAGIC, 10)
++#define ZEROMOUNT_IOC_GET_STATUS _IOR(ZEROMOUNT_IOC_MAGIC, 11, int)
++#define MAX_LIST_BUFFER_SIZE	(64 * 1024)
++
++struct zeromount_ioctl_data {
++	char __user *virtual_path;
++	char __user *real_path;
++	unsigned int flags;
++};
++
++struct zeromount_rule {
++	struct hlist_node node;
++	struct hlist_node ino_node;
++	struct list_head list;
++	size_t vp_len;
++	char *virtual_path;
++	char *real_path;
++	unsigned long real_ino;
++	dev_t real_dev;
++	unsigned long v_ino;
++	dev_t v_dev;
++	bool is_new;
++	u32 flags;
++	struct rcu_head rcu;
++};
++
++struct zeromount_dir_node {
++	struct hlist_node node;
++	char *dir_path;
++	struct list_head children_names;
++	struct rcu_head rcu;
++};
++
++struct zeromount_child_name {
++	struct list_head list;
++	char *name;
++	unsigned char d_type;
++	struct rcu_head rcu;
++};
++
++struct zeromount_uid_node {
++	uid_t uid;
++	struct hlist_node node;
++	struct rcu_head rcu;
++};
++
++extern DECLARE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++extern struct list_head zeromount_rules_list;
++extern spinlock_t zeromount_lock;
++
++#ifdef CONFIG_ZEROMOUNT
++extern atomic_t zeromount_enabled;
++
++bool zeromount_should_skip(void);
++char *zeromount_resolve_path(const char *pathname);
++char *zeromount_build_absolute_path(int dfd, const char *name);
++struct filename *zeromount_getname_hook(struct filename *name);
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat);
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos);
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos);
++char *zeromount_get_virtual_path_for_inode(struct inode *inode);
++char *zeromount_get_static_vpath(struct inode *inode);
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino);
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask);
++bool zeromount_is_injected_file(struct inode *inode);
++bool zeromount_is_uid_blocked(uid_t uid);
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf);
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size);
++#else
++static inline bool zeromount_should_skip(void) { return true; }
++static inline char *zeromount_resolve_path(const char *p) { return NULL; }
++static inline char *zeromount_build_absolute_path(int dfd, const char *name) { return NULL; }
++static inline struct filename *zeromount_getname_hook(struct filename *name) { return name; }
++static inline void zeromount_inject_dents_common(struct file *f, void __user **d,
++						 int *c, loff_t *p, int compat) {}
++static inline void zeromount_inject_dents64(struct file *f, void __user **d,
++					    int *c, loff_t *p) {}
++static inline void zeromount_inject_dents(struct file *f, void __user **d,
++					  int *c, loff_t *p) {}
++static inline char *zeromount_get_virtual_path_for_inode(struct inode *inode) { return NULL; }
++static inline char *zeromount_get_static_vpath(struct inode *inode) { return NULL; }
++static inline void zeromount_spoof_mmap_metadata(struct inode *inode,
++						 dev_t *dev,
++						 unsigned long *ino) {}
++static inline bool zeromount_is_traversal_allowed(struct inode *inode, int mask) { return false; }
++static inline bool zeromount_is_injected_file(struct inode *inode) { return false; }
++static inline bool zeromount_is_uid_blocked(uid_t uid) { return false; }
++static inline int zeromount_spoof_statfs(const char __user *p, struct kstatfs *b) { return 0; }
++static inline ssize_t zeromount_spoof_xattr(struct dentry *d, const char *n,
++					    void *v, size_t s) { return -EOPNOTSUPP; }
++#endif
++
++#endif /* _LINUX_ZEROMOUNT_H */

--- a/patches/zeromount/60_zeromount-android14-6.1.patch
+++ b/patches/zeromount/60_zeromount-android14-6.1.patch
@@ -1,0 +1,2204 @@
+--- a/arch/arm64/configs/gki_defconfig	2026-03-01 03:03:02.821550482 +0100
++++ b/arch/arm64/configs/gki_defconfig	2026-03-01 03:05:45.806869045 +0100
+@@ -779,3 +779,4 @@
+ CONFIG_TMPFS_POSIX_ACL=y
+ CONFIG_KSU_SUSFS_SUS_KSTAT_REDIRECT=y
+ CONFIG_KSU_SUSFS_UNICODE_FILTER=y
++CONFIG_ZEROMOUNT=y
+--- a/fs/Kconfig	2026-03-01 03:03:00.881591002 +0100
++++ b/fs/Kconfig	2026-03-01 03:05:42.695000338 +0100
+@@ -387,6 +387,13 @@
+ config IO_WQ
+ 	bool
+ 
++config ZEROMOUNT
++	bool "ZeroMount Path Redirection Subsystem"
++	default y
++	help
++	  ZeroMount allows path redirection and virtual file injection
++	  without mounting filesystems. Useful for systemless modifications.
++
+ config KSU_SUSFS_SUS_KSTAT_REDIRECT
+ 	bool "SUSFS kstat redirect"
+ 	depends on KSU_SUSFS_SUS_KSTAT
+--- a/fs/Makefile	2026-03-01 03:03:00.917590249 +0100
++++ b/fs/Makefile	2026-03-01 03:05:43.810944714 +0100
+@@ -137,3 +137,4 @@
+ obj-$(CONFIG_EROFS_FS)		+= erofs/
+ obj-$(CONFIG_VBOXSF_FS)		+= vboxsf/
+ obj-$(CONFIG_ZONEFS_FS)		+= zonefs/
++obj-$(CONFIG_ZEROMOUNT)		+= zeromount.o
+--- a/fs/d_path.c	2026-03-01 03:03:00.945589665 +0100
++++ b/fs/d_path.c	2026-03-01 03:06:25.705657436 +0100
+@@ -8,6 +8,10 @@
+ #include <linux/prefetch.h>
+ #include "mount.h"
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ struct prepend_buffer {
+ 	char *buf;
+ 	int len;
+@@ -266,6 +270,24 @@
+ 	DECLARE_BUFFER(b, buf, buflen);
+ 	struct path root;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (path->dentry && d_backing_inode(path->dentry)) {
++		char *v_path = zeromount_get_static_vpath(d_backing_inode(path->dentry));
++
++		if (v_path) {
++			int len = strlen(v_path);
++			if (buflen < len + 1) {
++				kfree(v_path);
++				return ERR_PTR(-ENAMETOOLONG);
++			}
++			memcpy(buf, v_path, len);
++			buf[len] = '\0';
++			kfree(v_path);
++			return buf;
++		}
++	}
++#endif
++
+ 	/*
+ 	 * We have various synthetic filesystems that never get mounted.  On
+ 	 * these filesystems dentries are never used for lookup purposes, and
+--- a/fs/namei.c	2026-03-01 03:03:00.961472141 +0100
++++ b/fs/namei.c	2026-03-01 03:06:56.376756675 +0100
+@@ -54,6 +54,9 @@
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ extern bool susfs_check_unicode_bypass(const char __user *filename);
+ #endif
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ /* [Feb-1997 T. Schoebel-Theuer]
+  * Fundamental changes in the pathname lookup mechanisms (namei)
+@@ -212,6 +215,13 @@
+ 	result->uptr = filename;
+ 	result->aname = NULL;
+ 	audit_getname(result);
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!IS_ERR(result)) {
++		result = zeromount_getname_hook(result);
++	}
++#endif
++
+ 	return result;
+ }
+ 
+@@ -411,6 +421,18 @@
+ {
+ 	int ret;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	/*
+ 	 * Do the basic permission checks.
+ 	 */
+@@ -515,6 +537,18 @@
+ {
+ 	int retval;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	retval = sb_permission(inode->i_sb, inode, mask);
+ 	if (retval)
+ 		return retval;
+--- a/fs/proc/base.c	2026-03-01 03:03:01.545577133 +0100
++++ b/fs/proc/base.c	2026-03-01 03:07:20.388132665 +0100
+@@ -107,6 +107,9 @@
+ #include <trace/events/oom.h>
+ #include <trace/hooks/sched.h>
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include "fd.h"
+ 
+ #include "../../lib/kstrtox.h"
+@@ -1869,6 +1872,26 @@
+ 	if (!tmp)
+ 		return -ENOMEM;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (!zeromount_should_skip() && path->dentry) {
++		struct inode *inode = d_backing_inode(path->dentry);
++		if (inode) {
++			char *vpath = zeromount_get_static_vpath(inode);
++			if (vpath) {
++				int vlen = strlen(vpath);
++				if (vlen > buflen)
++					vlen = buflen;
++				if (copy_to_user(buffer, vpath, vlen) == 0) {
++					kfree(vpath);
++					kfree(tmp);
++					return vlen;
++				}
++				kfree(vpath);
++			}
++		}
++	}
++#endif
++
+ 	pathname = d_path(path, tmp, PATH_MAX);
+ 	len = PTR_ERR(pathname);
+ 	if (IS_ERR(pathname))
+--- a/fs/proc/task_mmu.c	2026-03-01 03:03:02.037566858 +0100
++++ b/fs/proc/task_mmu.c	2026-03-01 03:07:58.007149424 +0100
+@@ -21,6 +21,9 @@
+ #include <linux/uaccess.h>
+ #include <linux/pkeys.h>
+ #include <trace/hooks/mm.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #if defined(CONFIG_KSU_SUSFS_SUS_KSTAT) || defined(CONFIG_KSU_SUSFS_SUS_MAP)
+ #include <linux/susfs_def.h>
+ #endif
+@@ -322,6 +325,9 @@
+ #endif
+ 		dev = inode->i_sb->s_dev;
+ 		ino = inode->i_ino;
++#ifdef CONFIG_ZEROMOUNT
++		zeromount_spoof_mmap_metadata(inode, &dev, &ino);
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ bypass_orig_flow:
+ #endif
+--- a/fs/readdir.c	2026-03-01 03:03:02.085565855 +0100
++++ b/fs/readdir.c	2026-03-01 03:09:26.984750991 +0100
+@@ -24,6 +24,9 @@
+ 
+ #include <asm/unaligned.h>
+ 
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ #include <linux/susfs_def.h>
+ extern bool susfs_is_inode_sus_path(struct inode *inode);
+@@ -322,17 +325,37 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -342,6 +365,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -427,17 +453,37 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents64(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent64 __user * lastdirent;
+ 		typeof(lastdirent->d_off) d_off = buf.ctx.pos;
+@@ -448,6 +494,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -637,17 +686,37 @@
+ 		.count = count
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ #endif
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct compat_linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -657,6 +726,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+--- a/fs/stat.c	2026-03-01 03:03:02.097614919 +0100
++++ b/fs/stat.c	2026-03-01 03:10:16.535486093 +0100
+@@ -24,6 +24,9 @@
+ #include <linux/version.h>
+ #endif
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <asm/unistd.h>
+ 
+ #include "internal.h"
+@@ -260,6 +263,40 @@
+  *
+  * 0 will be returned on success, and a -ve error code if unsuccessful.
+  */
++#ifdef CONFIG_ZEROMOUNT
++static inline int zeromount_stat_hook(int dfd, struct filename *filename,
++                                      struct kstat *stat, unsigned int request_mask,
++                                      int flags) {
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
++    if (filename && filename->name) {
++        const char *kname = filename->name;
++        if (kname[0] != '/') {
++            char *abs_path = zeromount_build_absolute_path(dfd, kname);
++            if (abs_path) {
++                char *resolved = zeromount_resolve_path(abs_path);
++                if (resolved) {
++                    struct path zm_path;
++                    int zm_ret;
++                    zm_enter();
++                    zm_ret = kern_path(resolved, (flags & AT_SYMLINK_NOFOLLOW) ? 0 : LOOKUP_FOLLOW, &zm_path);
++                    zm_exit();
++                    kfree(resolved);
++                    kfree(abs_path);
++                    if (zm_ret == 0) {
++                        zm_ret = vfs_getattr(&zm_path, stat, request_mask,
++                                             (flags & AT_SYMLINK_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
++                        path_put(&zm_path);
++                        return zm_ret;
++                    }
++                } else {
++                    kfree(abs_path);
++                }
++            }
++        }
++    }
++    return -ENOENT;
++}
++#endif
+ static int vfs_statx(int dfd, struct filename *filename, int flags,
+ 	      struct kstat *stat, u32 request_mask)
+ {
+@@ -279,6 +316,14 @@
+ orig_flow:
+ #endif
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (filename) {
++		int zm_ret = zeromount_stat_hook(dfd, filename, stat, request_mask, flags);
++		if (zm_ret != -ENOENT)
++			return zm_ret;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ 	if (susfs_check_unicode_bypass(filename->uptr))
+ 		return -ENOENT;
+--- a/fs/statfs.c	2026-03-01 03:03:02.109565353 +0100
++++ b/fs/statfs.c	2026-03-01 03:10:36.510976173 +0100
+@@ -14,6 +14,9 @@
+ #include "mount.h"
+ #endif
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static int flags_by_mnt(int mnt_flags)
+ {
+@@ -118,7 +121,14 @@
+ retry:
+ 	error = user_path_at(AT_FDCWD, pathname, lookup_flags, &path);
+ 	if (!error) {
++#ifdef CONFIG_ZEROMOUNT
++		int spoofed;
++#endif
+ 		error = vfs_statfs(&path, st);
++#ifdef CONFIG_ZEROMOUNT
++		spoofed = zeromount_spoof_statfs(pathname, st);
++		(void)spoofed;
++#endif
+ 		path_put(&path);
+ 		if (retry_estale(error, lookup_flags)) {
+ 			lookup_flags |= LOOKUP_REVAL;
+--- a/fs/xattr.c	2026-03-01 03:03:02.361560090 +0100
++++ b/fs/xattr.c	2026-03-01 03:10:50.234625845 +0100
+@@ -24,6 +24,9 @@
+ #include <linux/posix_acl_xattr.h>
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include "internal.h"
+ 
+@@ -415,6 +418,15 @@
+ 	struct inode *inode = dentry->d_inode;
+ 	int error;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	{
++		ssize_t zm_ret;
++		zm_ret = zeromount_spoof_xattr(dentry, name, value, size);
++		if (zm_ret != -EOPNOTSUPP)
++			return zm_ret;
++	}
++#endif
++
+ 	error = xattr_permission(mnt_userns, inode, name, MAY_READ);
+ 	if (error)
+ 		return error;
+--- /dev/null	2026-03-01 02:52:35.802537893 +0100
++++ b/fs/zeromount.c	2026-03-01 03:05:05.111203827 +0100
+@@ -0,0 +1,1526 @@
++#include <linux/module.h>
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/fs.h>
++#include <linux/dcache.h>
++#include <linux/path.h>
++#include <linux/namei.h>
++#include <linux/sched.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/uaccess.h>
++#include <linux/dirent.h>
++#include <linux/miscdevice.h>
++#include <linux/cred.h>
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include <linux/zeromount.h>
++#include <linux/kobject.h>
++#include <linux/sysfs.h>
++#include <linux/statfs.h>
++#include <linux/file.h>
++#include <linux/fs_struct.h>
++#ifdef CONFIG_KSU_SUSFS
++#include <linux/susfs.h>
++#endif
++#include <linux/reboot.h>
++#include <linux/bitmap.h>
++
++int zeromount_debug_level = 0;
++
++DEFINE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++LIST_HEAD(zeromount_rules_list);
++DEFINE_SPINLOCK(zeromount_lock);
++
++atomic_t zeromount_enabled = ATOMIC_INIT(0);
++static atomic_t zeromount_dirs_count = ATOMIC_INIT(0);
++static atomic_t zeromount_rule_count = ATOMIC_INIT(0);
++static DECLARE_BITMAP(zm_bloom, ZM_BLOOM_BITS);
++#define ZEROMOUNT_DISABLED() (atomic_read(&zeromount_enabled) == 0)
++
++static inline void zm_bloom_add(u32 hash)
++{
++	set_bit(hash & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static inline bool zm_bloom_test(u32 hash)
++{
++	return test_bit(hash & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static void zm_bloom_rebuild(void)
++{
++	struct zeromount_rule *rule;
++	int count = 0;
++
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		u32 h = full_name_hash(NULL, rule->virtual_path, rule->vp_len);
++		zm_bloom_add(h);
++		count++;
++	}
++	ZM_DBG("bloom: rebuilt (%d rules)\n", count);
++}
++
++struct linux_dirent {
++	unsigned long	d_ino;
++	unsigned long	d_off;
++	unsigned short	d_reclen;
++	char		d_name[];
++};
++
++static unsigned long zm_ino_adb = 0;
++static unsigned long zm_ino_modules = 0;
++
++static inline bool zeromount_is_critical_process(void)
++{
++	const char *comm = current->comm;
++
++	switch (comm[0]) {
++	case 'i': if (comm[1] == 'n' && comm[2] == 'i') return true; break;
++	case 'u': if (comm[1] == 'e' && comm[2] == 'v') return true; break;
++	case 'v': if (comm[1] == 'o' && comm[2] == 'l') return true; break;
++	}
++	if (current->flags & PF_KTHREAD)
++		return true;
++	return false;
++}
++
++bool zeromount_should_skip(void)
++{
++	if (ZEROMOUNT_DISABLED())
++		return true;
++	if (zm_is_recursive())
++		return true;
++	if (unlikely(in_interrupt() || in_nmi() || oops_in_progress))
++		return true;
++	if (!current || !current->mm)
++		return true;
++	if (current->flags & PF_EXITING)
++		return true;
++	if (zeromount_is_critical_process())
++		return true;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return true;
++#endif
++	return false;
++}
++EXPORT_SYMBOL(zeromount_should_skip);
++
++bool zeromount_is_uid_blocked(uid_t uid)
++{
++	struct zeromount_uid_node *entry;
++
++	if (ZEROMOUNT_DISABLED())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return true;
++#endif
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_uid_ht, entry, node, uid) {
++		if (entry->uid == uid) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_uid_blocked);
++
++bool zeromount_match_path(const char *input_path, const char *rule_path)
++{
++	if (!input_path || !rule_path)
++		return false;
++	if (strcmp(input_path, rule_path) == 0)
++		return true;
++	if (strncmp(input_path, "/system", 7) == 0) {
++		if (strcmp(input_path + 7, rule_path) == 0)
++			return true;
++	}
++	return false;
++}
++
++/* Zero-alloc normalize: compute adjusted base and length in-place */
++static inline void zeromount_normalize_inline(const char *path,
++					      const char **out_p,
++					      size_t *out_len)
++{
++	const char *p = path;
++	size_t len;
++
++	if (strncmp(path, "/system/", 8) == 0)
++		p = path + 7;
++
++	len = strlen(p);
++	while (len > 1 && p[len - 1] == '/')
++		len--;
++
++	*out_p = p;
++	*out_len = len;
++}
++
++/* Alloc variant for callers that need a persistent copy */
++static char *zeromount_normalize_path(const char *path)
++{
++	const char *p;
++	size_t len;
++	char *normalized;
++
++	if (!path)
++		return NULL;
++
++	zeromount_normalize_inline(path, &p, &len);
++
++	normalized = kmalloc(len + 1, GFP_KERNEL);
++	if (!normalized)
++		return NULL;
++
++	memcpy(normalized, p, len);
++	normalized[len] = '\0';
++	return normalized;
++}
++
++static void zeromount_free_rule_rcu(struct rcu_head *head)
++{
++	struct zeromount_rule *rule = container_of(head, struct zeromount_rule, rcu);
++
++	kfree(rule->virtual_path);
++	kfree(rule->real_path);
++	kfree(rule);
++}
++
++static void zeromount_free_child_rcu(struct rcu_head *head)
++{
++	struct zeromount_child_name *child =
++		container_of(head, struct zeromount_child_name, rcu);
++
++	kfree(child->name);
++	kfree(child);
++}
++
++static void zeromount_free_dir_node_rcu(struct rcu_head *head)
++{
++	struct zeromount_dir_node *node =
++		container_of(head, struct zeromount_dir_node, rcu);
++
++	kfree(node->dir_path);
++	kfree(node);
++}
++
++static void zeromount_flush_parent(const char *full_path)
++{
++	char *path_copy, *last_slash, *parent_str, *child_name;
++	struct path parent;
++
++	path_copy = kstrdup(full_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_str = path_copy;
++	child_name = last_slash + 1;
++
++	if (*child_name == '\0') {
++		kfree(path_copy);
++		return;
++	}
++
++	if (kern_path(parent_str, LOOKUP_FOLLOW, &parent) == 0) {
++		struct dentry *child;
++
++		inode_lock(parent.dentry->d_inode);
++		child = lookup_one_len(child_name, parent.dentry,
++				       strlen(child_name));
++		if (!IS_ERR(child)) {
++			d_invalidate(child);
++			d_drop(child);
++			dput(child);
++		}
++		inode_unlock(parent.dentry->d_inode);
++		path_put(&parent);
++	}
++
++	kfree(path_copy);
++}
++
++static void zeromount_flush_dcache(const char *path_name)
++{
++	struct path path;
++	int err;
++
++	zm_enter();
++	err = kern_path(path_name, LOOKUP_FOLLOW, &path);
++	if (!err) {
++		d_invalidate(path.dentry);
++		d_drop(path.dentry);
++		path_put(&path);
++	} else if (err == -ENOENT) {
++		zeromount_flush_parent(path_name);
++	}
++	zm_exit();
++}
++
++static void zeromount_force_refresh_all(void)
++{
++	struct zeromount_rule *rule;
++	char **paths = NULL;
++	int count = 0, i = 0;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list)
++		count++;
++	spin_unlock(&zeromount_lock);
++
++	if (count == 0)
++		return;
++
++	paths = kvmalloc_array(count, sizeof(char *), GFP_KERNEL);
++	if (!paths)
++		return;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		if (i >= count)
++			break;
++		paths[i] = kstrdup(rule->virtual_path, GFP_ATOMIC);
++		if (!paths[i])
++			break;
++		i++;
++	}
++	spin_unlock(&zeromount_lock);
++
++	for (count = i, i = 0; i < count; i++) {
++		zeromount_flush_dcache(paths[i]);
++		kfree(paths[i]);
++	}
++	kvfree(paths);
++}
++
++static unsigned long zeromount_generate_ino(const char *dir, const char *name)
++{
++	u32 h1 = full_name_hash(NULL, dir, strlen(dir));
++	u32 h2 = full_name_hash(NULL, name, strlen(name));
++
++	return (unsigned long)(h1 ^ h2);
++}
++
++char *zeromount_get_virtual_path_for_inode(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *found_path = NULL;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return NULL;
++	if (zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			if (READ_ONCE(rule->is_new))
++				found_path = kstrdup(rule->virtual_path,
++						     GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return found_path;
++}
++EXPORT_SYMBOL(zeromount_get_virtual_path_for_inode);
++
++/* Returns kstrdup'd copy; caller must kfree. GFP_ATOMIC safe from any context. */
++char *zeromount_get_static_vpath(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *copy = NULL;
++
++	if (unlikely(!inode || !inode->i_sb))
++		return NULL;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			copy = kstrdup(rule->virtual_path, GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return copy;
++}
++EXPORT_SYMBOL(zeromount_get_static_vpath);
++
++/* Spoof dev/ino in /proc/PID/maps for redirected mmap'd files */
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (unlikely(!inode || !dev || !ino))
++		return;
++	if (zeromount_should_skip())
++		return;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			*dev = READ_ONCE(rule->v_dev);
++			*ino = READ_ONCE(rule->v_ino);
++			break;
++		}
++	}
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(zeromount_spoof_mmap_metadata);
++
++static unsigned long zeromount_get_inode_by_path(const char *path_str)
++{
++	struct path path;
++	struct inode *inode;
++	unsigned long ino = 0;
++
++	if (kern_path(path_str, LOOKUP_FOLLOW, &path) == 0) {
++		inode = d_backing_inode(path.dentry);
++		if (inode)
++			ino = inode->i_ino;
++		path_put(&path);
++	}
++	return ino;
++}
++
++static void zeromount_refresh_critical_inodes(void)
++{
++	if (READ_ONCE(zm_ino_adb) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_adb, ino);
++	}
++	if (READ_ONCE(zm_ino_modules) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb/modules");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_modules, ino);
++	}
++}
++
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask)
++{
++	if (!inode || zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return false;
++#endif
++	if (!(mask & MAY_EXEC))
++		return false;
++
++	if ((READ_ONCE(zm_ino_adb) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_adb)) ||
++	    (READ_ONCE(zm_ino_modules) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_modules)))
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_traversal_allowed);
++
++bool zeromount_is_injected_file(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return false;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return false;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_injected_file);
++
++char *zeromount_resolve_path(const char *pathname)
++{
++	struct zeromount_rule *rule;
++	char *target = NULL;
++	const char *normalized;
++	size_t norm_len;
++	u32 hash;
++
++	if (zeromount_is_critical_process())
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++	if (ZEROMOUNT_DISABLED() ||
++	    zeromount_is_uid_blocked(current_uid().val) || !pathname)
++		return NULL;
++
++	zeromount_normalize_inline(pathname, &normalized, &norm_len);
++	hash = full_name_hash(NULL, normalized, norm_len);
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	if (!zm_bloom_test(hash)) {
++		ZM_TRACE("bloom: reject hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++		return NULL;
++	}
++	ZM_DBG("bloom: pass hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_rules_ht, rule, node, hash) {
++		if (rule->vp_len == norm_len &&
++		    memcmp(normalized, rule->virtual_path, norm_len) == 0) {
++			if (rule->flags & ZM_FLAG_ACTIVE) {
++				target = kstrdup(rule->real_path, GFP_ATOMIC);
++				break;
++			}
++		}
++	}
++	rcu_read_unlock();
++	return target;
++}
++EXPORT_SYMBOL(zeromount_resolve_path);
++
++static char *zeromount_resolve_dirfd_path(int dfd, char *buf, int buflen)
++{
++	struct fd f;
++	char *path;
++
++	if (dfd == AT_FDCWD) {
++		struct path pwd;
++
++		if (unlikely(!current->fs))
++			return ERR_PTR(-ENOENT);
++		get_fs_pwd(current->fs, &pwd);
++		path = d_path(&pwd, buf, buflen);
++		path_put(&pwd);
++		return path;
++	}
++
++	f = fdget(dfd);
++	if (!f.file)
++		return ERR_PTR(-EBADF);
++
++	path = d_path(&f.file->f_path, buf, buflen);
++	fdput(f);
++	return path;
++}
++
++char *zeromount_build_absolute_path(int dfd, const char *name)
++{
++	char *page_buf, *dir_path, *abs_path;
++	size_t dir_len, name_len;
++
++	if (!name || name[0] == '/' || *name == '\0')
++		return NULL;
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return NULL;
++
++	dir_path = zeromount_resolve_dirfd_path(dfd, page_buf, PATH_MAX);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	dir_len = strlen(dir_path);
++	name_len = strlen(name);
++
++	if (dir_len > PATH_MAX || name_len > NAME_MAX ||
++	    dir_len + name_len + 2 > PATH_MAX) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	abs_path = kmalloc(dir_len + 1 + name_len + 1, GFP_KERNEL);
++	if (abs_path) {
++		memcpy(abs_path, dir_path, dir_len);
++		abs_path[dir_len] = '/';
++		memcpy(abs_path + dir_len + 1, name, name_len + 1);
++	}
++
++	__putname(page_buf);
++	return abs_path;
++}
++EXPORT_SYMBOL(zeromount_build_absolute_path);
++
++struct filename *zeromount_getname_hook(struct filename *name)
++{
++	char *target_path;
++	struct filename *new_name;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val) ||
++	    !name || name->name[0] != '/')
++		return name;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return name;
++#endif
++
++	zm_enter();
++
++	target_path = zeromount_resolve_path(name->name);
++	if (!target_path) {
++		zm_exit();
++		return name;
++	}
++
++	new_name = getname_kernel(target_path);
++	kfree(target_path);
++
++	if (IS_ERR(new_name)) {
++		zm_exit();
++		return name;
++	}
++
++	putname(name);
++	zm_exit();
++	return new_name;
++}
++
++/* Merged readdir injection: compat=0 for dirent64, compat=1 for dirent */
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat)
++{
++	char *page_buf, *dir_path;
++	unsigned long v_index;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return;
++#endif
++
++	if (atomic_read(&zeromount_dirs_count) == 0 &&
++	    *pos < ZEROMOUNT_MAGIC_POS)
++		return;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return;
++
++	dir_path = d_path(&file->f_path, page_buf, PAGE_SIZE);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return;
++	}
++
++	/* Skip if this directory is itself redirected */
++	{
++		const char *norm_p;
++		size_t norm_len;
++		u32 dir_hash;
++		bool is_redirected = false;
++
++		zeromount_normalize_inline(dir_path, &norm_p, &norm_len);
++		dir_hash = full_name_hash(NULL, norm_p, norm_len);
++
++		rcu_read_lock();
++		{
++			struct zeromount_rule *rule;
++
++			hash_for_each_possible_rcu(zeromount_rules_ht, rule,
++						   node, dir_hash) {
++				if (rule->vp_len == norm_len &&
++				    memcmp(norm_p, rule->virtual_path,
++					   norm_len) == 0 &&
++				    (rule->flags & ZM_FLAG_ACTIVE)) {
++					is_redirected = true;
++					break;
++				}
++			}
++		}
++		rcu_read_unlock();
++
++		if (is_redirected) {
++			__putname(page_buf);
++			return;
++		}
++	}
++
++	if (*pos >= ZEROMOUNT_MAGIC_POS) {
++		v_index = *pos - ZEROMOUNT_MAGIC_POS;
++	} else {
++		v_index = 0;
++	}
++
++	{
++		struct zeromount_dir_node *zm_dir;
++		struct zeromount_child_name *zm_child;
++		const char *normalized;
++		size_t normalized_len;
++		u32 zm_hash;
++		unsigned long cur_idx = 0;
++
++		zeromount_normalize_inline(dir_path, &normalized,
++					  &normalized_len);
++		zm_hash = full_name_hash(NULL, normalized, normalized_len);
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_dirs_ht, zm_dir,
++					   node, zm_hash) {
++			if (strlen(zm_dir->dir_path) != normalized_len ||
++			    memcmp(normalized, zm_dir->dir_path,
++				   normalized_len) != 0)
++				continue;
++
++			if (*pos < ZEROMOUNT_MAGIC_POS)
++				*pos = ZEROMOUNT_MAGIC_POS;
++
++			list_for_each_entry_rcu(zm_child,
++						&zm_dir->children_names,
++						list) {
++				char name_local[256];
++				unsigned char type_local;
++				int name_len, reclen;
++				unsigned long fake_ino;
++
++				if (cur_idx++ < v_index)
++					continue;
++
++				strscpy(name_local, zm_child->name,
++					sizeof(name_local));
++				type_local = zm_child->d_type;
++				name_len = strlen(name_local);
++
++				if (compat) {
++					struct linux_dirent __user *de;
++
++					reclen = ALIGN(offsetof(struct linux_dirent, d_name) + name_len + 2, 4);
++					if (*count < reclen)
++						break;
++					de = (struct linux_dirent __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de->d_off) ||
++					    put_user(reclen, &de->d_reclen) ||
++					    copy_to_user(de->d_name, name_local, name_len) ||
++					    put_user(0, de->d_name + name_len) ||
++					    put_user(type_local, ((char __user *)de) + reclen - 1))
++						break;
++				} else {
++					struct linux_dirent64 __user *de64;
++
++					reclen = ALIGN(offsetof(struct linux_dirent64, d_name) + name_len + 1, sizeof(u64));
++					if (*count < reclen)
++						break;
++					de64 = (struct linux_dirent64 __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de64->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de64->d_off) ||
++					    put_user(reclen, &de64->d_reclen) ||
++					    put_user(type_local, &de64->d_type) ||
++					    copy_to_user(de64->d_name, name_local, name_len) ||
++					    put_user(0, de64->d_name + name_len))
++						break;
++				}
++
++				*dirent = (void __user *)((char __user *)*dirent + reclen);
++				*count -= reclen;
++				v_index++;
++				*pos = ZEROMOUNT_MAGIC_POS + v_index;
++			}
++			break;
++		}
++		rcu_read_unlock();
++	}
++
++	__putname(page_buf);
++}
++
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 0);
++}
++
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 1);
++}
++
++#define EROFS_SUPER_MAGIC 0xE0F5E1E2
++#define EXT4_SUPER_MAGIC  0xEF53
++#define F2FS_SUPER_MAGIC  0xF2F52010
++
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf)
++{
++	char *kpath;
++	char *resolved;
++	int ret = 0;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return 0;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return 0;
++#endif
++
++	kpath = strndup_user(pathname, PATH_MAX);
++	if (IS_ERR(kpath))
++		return 0;
++
++	resolved = zeromount_resolve_path(kpath);
++	if (!resolved) {
++		kfree(kpath);
++		return 0;
++	}
++
++	if (strncmp(kpath, "/system", 7) == 0 ||
++	    strncmp(kpath, "/vendor", 7) == 0 ||
++	    strncmp(kpath, "/product", 8) == 0 ||
++	    strncmp(kpath, "/odm", 4) == 0) {
++		buf->f_type = EROFS_SUPER_MAGIC;
++		ret = 1;
++	}
++
++	kfree(kpath);
++	kfree(resolved);
++	return ret;
++}
++EXPORT_SYMBOL(zeromount_spoof_statfs);
++
++static const char *zeromount_get_selinux_context(const char *vpath)
++{
++	if (!vpath)
++		return NULL;
++
++	if (strncmp(vpath, "/lib64", 6) == 0 ||
++	    strncmp(vpath, "/lib", 4) == 0)
++		return "u:object_r:system_lib_file:s0";
++
++	if (strncmp(vpath, "/bin", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/fonts", 6) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/framework", 10) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/etc", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/vendor", 7) == 0)
++		return "u:object_r:vendor_file:s0";
++
++	if (strncmp(vpath, "/product", 8) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (vpath[0] == '/')
++		return "u:object_r:system_file:s0";
++
++	return NULL;
++}
++
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size)
++{
++	struct inode *inode;
++	char *vpath;
++	const char *context;
++	size_t ctx_len;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return -EOPNOTSUPP;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return -EOPNOTSUPP;
++#endif
++
++	if (!dentry || !name)
++		return -EOPNOTSUPP;
++
++	if (strcmp(name, "security.selinux") != 0)
++		return -EOPNOTSUPP;
++
++	inode = d_backing_inode(dentry);
++	if (!inode)
++		return -EOPNOTSUPP;
++
++	vpath = zeromount_get_virtual_path_for_inode(inode);
++	if (!vpath)
++		return -EOPNOTSUPP;
++
++	context = zeromount_get_selinux_context(vpath);
++	kfree(vpath);
++
++	if (!context)
++		return -EOPNOTSUPP;
++
++	ctx_len = strlen(context) + 1;
++
++	if (size == 0)
++		return ctx_len;
++	if (size < ctx_len)
++		return -ERANGE;
++
++	memcpy(value, context, ctx_len);
++	return ctx_len;
++}
++EXPORT_SYMBOL(zeromount_spoof_xattr);
++
++static void zeromount_auto_inject_parent(const char *v_path,
++					 unsigned char type, int depth)
++{
++	char *parent_path, *name, *path_copy, *last_slash;
++	struct zeromount_dir_node *dir_node = NULL, *curr;
++	struct zeromount_child_name *child;
++	u32 hash;
++	bool child_exists = false;
++
++	if (depth > 20)
++		return;
++
++	/* Existing path on real fs means all ancestors exist too */
++	{
++		struct path check;
++		if (kern_path(v_path, LOOKUP_FOLLOW, &check) == 0) {
++			path_put(&check);
++			return;
++		}
++	}
++
++	path_copy = kstrdup(v_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_path = path_copy;
++	name = last_slash + 1;
++
++	/* Skip if parent dir is VFS-redirected */
++	{
++		u32 parent_hash = full_name_hash(NULL, parent_path,
++						 strlen(parent_path));
++		struct zeromount_rule *parent_rule;
++		bool parent_redirected = false;
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_rules_ht, parent_rule,
++					   node, parent_hash) {
++			if (strcmp(parent_rule->virtual_path, parent_path) == 0 &&
++			    READ_ONCE(parent_rule->is_new)) {
++				parent_redirected = true;
++				break;
++			}
++		}
++		rcu_read_unlock();
++
++		if (parent_redirected) {
++			kfree(path_copy);
++			return;
++		}
++	}
++
++	zeromount_auto_inject_parent(parent_path, DT_DIR, depth + 1);
++
++	hash = full_name_hash(NULL, parent_path, strlen(parent_path));
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_possible(zeromount_dirs_ht, curr, node, hash) {
++		if (strcmp(curr->dir_path, parent_path) == 0) {
++			dir_node = curr;
++			break;
++		}
++	}
++
++	if (!dir_node) {
++		dir_node = kzalloc(sizeof(*dir_node), GFP_ATOMIC);
++		if (!dir_node)
++			goto unlock_out;
++
++		dir_node->dir_path = kstrdup(parent_path, GFP_ATOMIC);
++		INIT_LIST_HEAD(&dir_node->children_names);
++		hash_add_rcu(zeromount_dirs_ht, &dir_node->node, hash);
++		atomic_inc(&zeromount_dirs_count);
++	}
++
++	list_for_each_entry(child, &dir_node->children_names, list) {
++		if (strcmp(child->name, name) == 0) {
++			child_exists = true;
++			break;
++		}
++	}
++
++	if (!child_exists) {
++		child = kzalloc(sizeof(*child), GFP_ATOMIC);
++		if (child) {
++			child->name = kstrdup(name, GFP_ATOMIC);
++			child->d_type = (type == DT_DIR) ? 4 : 8;
++			list_add_tail_rcu(&child->list,
++					  &dir_node->children_names);
++		}
++	}
++
++unlock_out:
++	spin_unlock(&zeromount_lock);
++	kfree(path_copy);
++}
++
++static int zeromount_ioctl_add_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule;
++	char *v_path_raw, *v_path, *r_path;
++	struct path path;
++	unsigned char type;
++	u32 hash;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	r_path = strndup_user(data.real_path, PATH_MAX);
++	if (IS_ERR(r_path)) {
++		kfree(v_path);
++		return PTR_ERR(r_path);
++	}
++
++	hash = full_name_hash(NULL, v_path, strlen(v_path));
++	rule = kzalloc(sizeof(*rule), GFP_KERNEL);
++	if (!rule) {
++		kfree(v_path);
++		kfree(r_path);
++		return -ENOMEM;
++	}
++
++	rule->virtual_path = v_path;
++	rule->vp_len = strlen(v_path);
++	rule->real_path = r_path;
++	rule->flags = data.flags | ZM_FLAG_ACTIVE;
++	rule->is_new = false;
++
++	if (zm_ino_adb == 0)
++		zeromount_refresh_critical_inodes();
++
++	if (kern_path(r_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *inode = d_backing_inode(path.dentry);
++
++		if (inode) {
++			rule->real_ino = inode->i_ino;
++			rule->real_dev = inode->i_sb->s_dev;
++		}
++		path_put(&path);
++	} else {
++		rule->real_ino = 0;
++		rule->real_dev = 0;
++	}
++
++	/* Capture virtual path's dev/ino for maps spoofing.
++	 * Replacement rules use real inode; injected files use
++	 * parent device + generated ino. */
++	zm_enter();
++	if (kern_path(v_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *vinode = d_backing_inode(path.dentry);
++
++		if (vinode) {
++			rule->v_ino = vinode->i_ino;
++			rule->v_dev = vinode->i_sb->s_dev;
++		}
++		path_put(&path);
++	}
++	zm_exit();
++
++	if (rule->v_ino == 0) {
++		rule->v_ino = zeromount_generate_ino(v_path, r_path);
++		{
++			char *parent_copy = kstrdup(v_path, GFP_KERNEL);
++
++			if (parent_copy) {
++				char *slash = strrchr(parent_copy, '/');
++
++				if (slash && slash != parent_copy) {
++					*slash = '\0';
++					zm_enter();
++					if (kern_path(parent_copy, LOOKUP_FOLLOW,
++						      &path) == 0) {
++						struct inode *pinode =
++							d_backing_inode(path.dentry);
++						if (pinode)
++							rule->v_dev = pinode->i_sb->s_dev;
++						path_put(&path);
++					}
++					zm_exit();
++				}
++				kfree(parent_copy);
++			}
++		}
++	}
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_rules_ht, &rule->node, hash);
++	zm_bloom_add(hash);
++	ZM_DBG("bloom: add hash=0x%08x path=%s\n", hash, rule->virtual_path);
++	if (rule->real_ino != 0) {
++		unsigned long ino_key = rule->real_ino ^ rule->real_dev;
++
++		hash_add_rcu(zeromount_ino_ht, &rule->ino_node, ino_key);
++	}
++	list_add_tail(&rule->list, &zeromount_rules_list);
++	atomic_inc(&zeromount_rule_count);
++	spin_unlock(&zeromount_lock);
++
++	type = DT_REG;
++	if (data.flags & ZM_FLAG_IS_DIR)
++		type = DT_DIR;
++
++	if (kern_path(rule->virtual_path, LOOKUP_FOLLOW, &path) == 0) {
++		path_put(&path);
++	} else {
++		zeromount_auto_inject_parent(rule->virtual_path, type, 0);
++		WRITE_ONCE(rule->is_new, true);
++	}
++	zeromount_flush_dcache(rule->virtual_path);
++	return 0;
++}
++
++static void zeromount_cleanup_parent_dir(char *v_path)
++{
++	char *end = v_path + strlen(v_path);
++	char *last_slash, *p;
++	struct zeromount_dir_node *dir_node;
++	struct zeromount_child_name *child, *tmp_child;
++	u32 hash;
++	bool pruned;
++
++	do {
++		pruned = false;
++		last_slash = strrchr(v_path, '/');
++		if (!last_slash || last_slash == v_path)
++			break;
++
++		*last_slash = '\0';
++		hash = full_name_hash(NULL, v_path, strlen(v_path));
++
++		hash_for_each_possible(zeromount_dirs_ht, dir_node,
++				       node, hash) {
++			if (strcmp(dir_node->dir_path, v_path) != 0)
++				continue;
++
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				if (strcmp(child->name, last_slash + 1) == 0) {
++					list_del_rcu(&child->list);
++					call_rcu(&child->rcu,
++						 zeromount_free_child_rcu);
++					break;
++				}
++			}
++
++			if (list_empty(&dir_node->children_names)) {
++				hash_del_rcu(&dir_node->node);
++				atomic_dec(&zeromount_dirs_count);
++				call_rcu(&dir_node->rcu,
++					 zeromount_free_dir_node_rcu);
++				pruned = true;
++			}
++			break;
++		}
++	} while (pruned);
++
++	for (p = v_path; p < end; p++)
++		if (*p == '\0')
++			*p = '/';
++}
++
++static int zeromount_ioctl_del_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule = NULL;
++	struct hlist_node *tmp;
++	char *v_path_raw, *v_path;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		if (strcmp(rule->virtual_path, v_path) == 0) {
++			hash_del_rcu(&rule->node);
++			if (rule->real_ino != 0)
++				hash_del_rcu(&rule->ino_node);
++			list_del(&rule->list);
++			found = true;
++			break;
++		}
++	}
++	if (found)
++		zeromount_cleanup_parent_dir(v_path);
++	if (found)
++		atomic_dec(&zeromount_rule_count);
++	zm_bloom_rebuild();
++	spin_unlock(&zeromount_lock);
++
++	if (found && rule)
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++
++	kfree(v_path);
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_clear_rules(void)
++{
++	struct zeromount_rule *rule;
++	struct zeromount_uid_node *uid_node;
++	struct hlist_node *tmp;
++	int bkt;
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		hash_del_rcu(&rule->node);
++		if (rule->real_ino != 0)
++			hash_del_rcu(&rule->ino_node);
++		list_del(&rule->list);
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++	}
++
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, uid_node, node) {
++		hash_del_rcu(&uid_node->node);
++		kfree_rcu(uid_node, rcu);
++	}
++
++	{
++		struct zeromount_dir_node *dir_node;
++		struct zeromount_child_name *child, *tmp_child;
++		int bkt2;
++		struct hlist_node *tmp2;
++
++		hash_for_each_safe(zeromount_dirs_ht, bkt2, tmp2,
++				   dir_node, node) {
++			hash_del_rcu(&dir_node->node);
++			atomic_dec(&zeromount_dirs_count);
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				list_del_rcu(&child->list);
++				call_rcu(&child->rcu,
++					 zeromount_free_child_rcu);
++			}
++			call_rcu(&dir_node->rcu,
++				 zeromount_free_dir_node_rcu);
++		}
++	}
++
++	atomic_set(&zeromount_rule_count, 0);
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	spin_unlock(&zeromount_lock);
++	return 0;
++}
++
++static int zeromount_ioctl_list_rules(unsigned long arg)
++{
++	struct zeromount_rule *rule;
++	char *kbuf;
++	int ret = 0;
++	size_t len = 0;
++	size_t remaining;
++	char __user *ubuf = (char __user *)arg;
++
++	kbuf = vmalloc(MAX_LIST_BUFFER_SIZE);
++	if (!kbuf)
++		return -ENOMEM;
++
++	memset(kbuf, 0, MAX_LIST_BUFFER_SIZE);
++	spin_lock(&zeromount_lock);
++
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		remaining = MAX_LIST_BUFFER_SIZE - len;
++		if (remaining <= 1) {
++			ret = -ENOBUFS;
++			break;
++		}
++		len += scnprintf(kbuf + len, remaining, "%s->%s\n",
++				 rule->real_path, rule->virtual_path);
++	}
++
++	spin_unlock(&zeromount_lock);
++
++	if (ret == -ENOBUFS) {
++		vfree(kbuf);
++		return ret;
++	}
++
++	if (copy_to_user(ubuf, kbuf, len))
++		ret = -EFAULT;
++	else
++		ret = len;
++
++	vfree(kbuf);
++	return ret;
++}
++
++static int zeromount_ioctl_add_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++	if (zeromount_is_uid_blocked(uid))
++		return -EEXIST;
++
++	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return -ENOMEM;
++
++	entry->uid = uid;
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_uid_ht, &entry->node, uid);
++	spin_unlock(&zeromount_lock);
++
++	return 0;
++}
++
++static int zeromount_ioctl_del_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++	struct hlist_node *tmp;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, entry, node) {
++		if (entry->uid == uid) {
++			hash_del_rcu(&entry->node);
++			found = true;
++			break;
++		}
++	}
++	spin_unlock(&zeromount_lock);
++
++	if (found && entry)
++		kfree_rcu(entry, rcu);
++
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_enable(void)
++{
++	atomic_set(&zeromount_enabled, 1);
++	return 0;
++}
++
++static int zeromount_ioctl_disable(void)
++{
++	atomic_set(&zeromount_enabled, 0);
++	return 0;
++}
++
++static long zeromount_ioctl(struct file *filp, unsigned int cmd,
++			    unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) != ZEROMOUNT_MAGIC_CODE)
++		return -ENOTTY;
++
++	if (cmd != ZEROMOUNT_IOC_GET_VERSION) {
++		if (!capable(CAP_SYS_ADMIN))
++			return -EPERM;
++	}
++
++	switch (cmd) {
++	case ZEROMOUNT_IOC_GET_VERSION:	return ZEROMOUNT_VERSION;
++	case ZEROMOUNT_IOC_ADD_RULE:	return zeromount_ioctl_add_rule(arg);
++	case ZEROMOUNT_IOC_DEL_RULE:	return zeromount_ioctl_del_rule(arg);
++	case ZEROMOUNT_IOC_CLEAR_ALL:	return zeromount_ioctl_clear_rules();
++	case ZEROMOUNT_IOC_ADD_UID:	return zeromount_ioctl_add_uid(arg);
++	case ZEROMOUNT_IOC_DEL_UID:	return zeromount_ioctl_del_uid(arg);
++	case ZEROMOUNT_IOC_GET_LIST:	return zeromount_ioctl_list_rules(arg);
++	case ZEROMOUNT_IOC_ENABLE:	return zeromount_ioctl_enable();
++	case ZEROMOUNT_IOC_DISABLE:	return zeromount_ioctl_disable();
++	case ZEROMOUNT_IOC_REFRESH:
++		zeromount_force_refresh_all();
++		return 0;
++	case ZEROMOUNT_IOC_GET_STATUS:	return atomic_read(&zeromount_enabled);
++	default:			return -EINVAL;
++	}
++}
++
++static struct kobject *zeromount_kobj;
++
++static ssize_t debug_show(struct kobject *kobj, struct kobj_attribute *attr,
++			  char *buf)
++{
++	return sprintf(buf, "%d\n", zeromount_debug_level);
++}
++
++static ssize_t debug_store(struct kobject *kobj, struct kobj_attribute *attr,
++			   const char *buf, size_t count)
++{
++	int val;
++
++	if (kstrtoint(buf, 10, &val) < 0)
++		return -EINVAL;
++	if (val < 0 || val > 2)
++		return -EINVAL;
++	zeromount_debug_level = val;
++	return count;
++}
++
++static struct kobj_attribute debug_attr =
++	__ATTR(debug, 0600, debug_show, debug_store);
++
++static struct attribute *zeromount_attrs[] = {
++	&debug_attr.attr,
++	NULL,
++};
++
++static struct attribute_group zeromount_attr_group = {
++	.attrs = zeromount_attrs,
++};
++
++static int zeromount_dev_open(struct inode *inode, struct file *file)
++{
++	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
++		return -EPERM;
++	return 0;
++}
++
++static const struct file_operations zeromount_fops = {
++	.owner		= THIS_MODULE,
++	.open		= zeromount_dev_open,
++	.unlocked_ioctl	= zeromount_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl	= zeromount_ioctl,
++#endif
++};
++
++static struct miscdevice zeromount_device = {
++	.minor	= MISC_DYNAMIC_MINOR,
++	.name	= "zeromount",
++	.fops	= &zeromount_fops,
++	.mode	= 0600,
++};
++
++static int zeromount_reboot_notify(struct notifier_block *nb,
++				   unsigned long action, void *data)
++{
++	atomic_set(&zeromount_enabled, 0);
++	synchronize_rcu();
++	return NOTIFY_OK;
++}
++
++static struct notifier_block zeromount_reboot_nb = {
++	.notifier_call = zeromount_reboot_notify,
++};
++
++static int __init __used zeromount_init(void)
++{
++	int ret;
++
++	spin_lock_init(&zeromount_lock);
++	register_reboot_notifier(&zeromount_reboot_nb);
++
++	ret = misc_register(&zeromount_device);
++	if (ret)
++		return ret;
++
++	zeromount_kobj = kobject_create_and_add("zeromount", kernel_kobj);
++	if (zeromount_kobj) {
++		ret = sysfs_create_group(zeromount_kobj,
++					&zeromount_attr_group);
++		if (ret)
++			pr_warn("ZeroMount: sysfs group creation failed: %d\n",
++				ret);
++	}
++
++	ZM_INFO("Loaded (debug=%d)\n", zeromount_debug_level);
++	return 0;
++}
++fs_initcall(zeromount_init);
++
+--- /dev/null	2026-03-01 02:52:35.802537893 +0100
++++ b/include/linux/zeromount.h	2026-03-01 03:05:05.113336004 +0100
+@@ -0,0 +1,200 @@
++#ifndef _LINUX_ZEROMOUNT_H
++#define _LINUX_ZEROMOUNT_H
++
++#include <linux/types.h>
++#include <linux/list.h>
++#include <linux/hashtable.h>
++#include <linux/spinlock.h>
++#include <linux/limits.h>
++#include <linux/atomic.h>
++#include <linux/uidgid.h>
++#include <linux/stat.h>
++#include <linux/ioctl.h>
++#include <linux/rcupdate.h>
++#include <linux/printk.h>
++#include <linux/sched.h>
++#include <linux/bitops.h>
++
++#define ZM_BLOOM_BITS     4096
++#define ZM_BLOOM_SHIFT    12
++#define ZM_BLOOM_MASK     (ZM_BLOOM_BITS - 1)
++
++/* Per-task recursion guard using android_oem_data1 bit 0.
++ * Survives CPU migration -- no preemption constraints needed. */
++#ifdef CONFIG_ANDROID_VENDOR_OEM_DATA
++#define ZM_RECURSIVE_BIT 0
++
++static inline void zm_enter(void)
++{
++	set_bit(ZM_RECURSIVE_BIT,
++		(unsigned long *)&current->android_oem_data1);
++}
++
++static inline void zm_exit(void)
++{
++	clear_bit(ZM_RECURSIVE_BIT,
++		  (unsigned long *)&current->android_oem_data1);
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return test_bit(ZM_RECURSIVE_BIT,
++			(unsigned long *)&current->android_oem_data1);
++}
++#else
++#define ZM_RECURSIVE_MARKER ((void *)0x5A4D)
++
++/* Only claim journal_info if it is free — avoids clobbering jbd2 handles
++ * held by user processes doing ext4 I/O. If already occupied, we treat
++ * the call as a no-op; zm_is_recursive() returns false so ZeroMount
++ * proceeds normally, which is safe since the occupied handle means we
++ * are in a filesystem transaction context where redirection is unwanted. */
++static inline void zm_enter(void)
++{
++	if (!current->journal_info)
++		current->journal_info = ZM_RECURSIVE_MARKER;
++}
++
++static inline void zm_exit(void)
++{
++	if (current->journal_info == ZM_RECURSIVE_MARKER)
++		current->journal_info = NULL;
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return current->journal_info == ZM_RECURSIVE_MARKER;
++}
++#endif
++
++extern int zeromount_debug_level;
++
++#define ZM_LOG(level, fmt, ...) \
++	do { \
++		if (zeromount_debug_level >= (level) && printk_ratelimit()) \
++			pr_info("ZeroMount: " fmt, ##__VA_ARGS__); \
++	} while (0)
++
++#define ZM_TRACE(fmt, ...) ZM_LOG(3, fmt, ##__VA_ARGS__)
++#define ZM_DBG(fmt, ...)  ZM_LOG(2, fmt, ##__VA_ARGS__)
++#define ZM_INFO(fmt, ...) ZM_LOG(1, fmt, ##__VA_ARGS__)
++#define ZM_ERR(fmt, ...)  pr_err("ZeroMount: " fmt, ##__VA_ARGS__)
++
++#define ZEROMOUNT_MAGIC_CODE	0x5A
++#define ZEROMOUNT_VERSION	1
++#define ZEROMOUNT_HASH_BITS	10
++#define ZM_FLAG_ACTIVE		(1 << 0)
++#define ZM_FLAG_IS_DIR		(1 << 7)
++#define ZEROMOUNT_MAGIC_POS	0x7000000000000000ULL
++
++#define ZEROMOUNT_IOC_MAGIC	ZEROMOUNT_MAGIC_CODE
++#define ZEROMOUNT_IOC_ADD_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 1, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_DEL_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 2, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_CLEAR_ALL	_IO(ZEROMOUNT_IOC_MAGIC, 3)
++#define ZEROMOUNT_IOC_GET_VERSION _IOR(ZEROMOUNT_IOC_MAGIC, 4, int)
++#define ZEROMOUNT_IOC_ADD_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 5, unsigned int)
++#define ZEROMOUNT_IOC_DEL_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 6, unsigned int)
++#define ZEROMOUNT_IOC_GET_LIST	_IOR(ZEROMOUNT_IOC_MAGIC, 7, int)
++#define ZEROMOUNT_IOC_ENABLE	_IO(ZEROMOUNT_IOC_MAGIC, 8)
++#define ZEROMOUNT_IOC_DISABLE	_IO(ZEROMOUNT_IOC_MAGIC, 9)
++#define ZEROMOUNT_IOC_REFRESH	_IO(ZEROMOUNT_IOC_MAGIC, 10)
++#define ZEROMOUNT_IOC_GET_STATUS _IOR(ZEROMOUNT_IOC_MAGIC, 11, int)
++#define MAX_LIST_BUFFER_SIZE	(64 * 1024)
++
++struct zeromount_ioctl_data {
++	char __user *virtual_path;
++	char __user *real_path;
++	unsigned int flags;
++};
++
++struct zeromount_rule {
++	struct hlist_node node;
++	struct hlist_node ino_node;
++	struct list_head list;
++	size_t vp_len;
++	char *virtual_path;
++	char *real_path;
++	unsigned long real_ino;
++	dev_t real_dev;
++	unsigned long v_ino;
++	dev_t v_dev;
++	bool is_new;
++	u32 flags;
++	struct rcu_head rcu;
++};
++
++struct zeromount_dir_node {
++	struct hlist_node node;
++	char *dir_path;
++	struct list_head children_names;
++	struct rcu_head rcu;
++};
++
++struct zeromount_child_name {
++	struct list_head list;
++	char *name;
++	unsigned char d_type;
++	struct rcu_head rcu;
++};
++
++struct zeromount_uid_node {
++	uid_t uid;
++	struct hlist_node node;
++	struct rcu_head rcu;
++};
++
++extern DECLARE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++extern struct list_head zeromount_rules_list;
++extern spinlock_t zeromount_lock;
++
++#ifdef CONFIG_ZEROMOUNT
++extern atomic_t zeromount_enabled;
++
++bool zeromount_should_skip(void);
++char *zeromount_resolve_path(const char *pathname);
++char *zeromount_build_absolute_path(int dfd, const char *name);
++struct filename *zeromount_getname_hook(struct filename *name);
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat);
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos);
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos);
++char *zeromount_get_virtual_path_for_inode(struct inode *inode);
++char *zeromount_get_static_vpath(struct inode *inode);
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino);
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask);
++bool zeromount_is_injected_file(struct inode *inode);
++bool zeromount_is_uid_blocked(uid_t uid);
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf);
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size);
++#else
++static inline bool zeromount_should_skip(void) { return true; }
++static inline char *zeromount_resolve_path(const char *p) { return NULL; }
++static inline char *zeromount_build_absolute_path(int dfd, const char *name) { return NULL; }
++static inline struct filename *zeromount_getname_hook(struct filename *name) { return name; }
++static inline void zeromount_inject_dents_common(struct file *f, void __user **d,
++						 int *c, loff_t *p, int compat) {}
++static inline void zeromount_inject_dents64(struct file *f, void __user **d,
++					    int *c, loff_t *p) {}
++static inline void zeromount_inject_dents(struct file *f, void __user **d,
++					  int *c, loff_t *p) {}
++static inline char *zeromount_get_virtual_path_for_inode(struct inode *inode) { return NULL; }
++static inline char *zeromount_get_static_vpath(struct inode *inode) { return NULL; }
++static inline void zeromount_spoof_mmap_metadata(struct inode *inode,
++						 dev_t *dev,
++						 unsigned long *ino) {}
++static inline bool zeromount_is_traversal_allowed(struct inode *inode, int mask) { return false; }
++static inline bool zeromount_is_injected_file(struct inode *inode) { return false; }
++static inline bool zeromount_is_uid_blocked(uid_t uid) { return false; }
++static inline int zeromount_spoof_statfs(const char __user *p, struct kstatfs *b) { return 0; }
++static inline ssize_t zeromount_spoof_xattr(struct dentry *d, const char *n,
++					    void *v, size_t s) { return -EOPNOTSUPP; }
++#endif
++
++#endif /* _LINUX_ZEROMOUNT_H */

--- a/patches/zeromount/60_zeromount-android15-6.6.patch
+++ b/patches/zeromount/60_zeromount-android15-6.6.patch
@@ -1,0 +1,2191 @@
+--- a/fs/Kconfig	2026-03-01 02:42:32.372399519 +0100
++++ b/fs/Kconfig	2026-03-01 02:42:39.801747392 +0100
+@@ -405,4 +405,11 @@
+ config IO_WQ
+ 	bool
+ 
++config ZEROMOUNT
++	bool "ZeroMount Path Redirection Subsystem"
++	default y
++	help
++	  ZeroMount allows path redirection and virtual file injection
++	  without mounting filesystems. Useful for systemless modifications.
++
+ endmenu
+--- a/fs/Makefile	2026-03-01 02:42:32.374541267 +0100
++++ b/fs/Makefile	2026-03-01 02:42:39.801971793 +0100
+@@ -137,3 +137,4 @@
+ obj-$(CONFIG_EROFS_FS)		+= erofs/
+ obj-$(CONFIG_VBOXSF_FS)		+= vboxsf/
+ obj-$(CONFIG_ZONEFS_FS)		+= zonefs/
++obj-$(CONFIG_ZEROMOUNT)		+= zeromount.o
+--- a/fs/d_path.c	2026-03-01 02:42:32.376659810 +0100
++++ b/fs/d_path.c	2026-03-01 02:42:39.802362766 +0100
+@@ -8,6 +8,10 @@
+ #include <linux/prefetch.h>
+ #include "mount.h"
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ 
+ struct prepend_buffer {
+ 	char *buf;
+@@ -267,6 +271,20 @@
+ 	DECLARE_BUFFER(b, buf, buflen);
+ 	struct path root;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (path->dentry && d_backing_inode(path->dentry)) {
++		char *v_path = zeromount_get_static_vpath(d_backing_inode(path->dentry));
++
++		if (v_path) {
++			prepend_char(&b, 0);
++			prepend(&b, v_path, strlen(v_path));
++			kfree(v_path);
++			return extract_string(&b);
++		}
++	}
++#endif
++
++
+ 	/*
+ 	 * We have various synthetic filesystems that never get mounted.  On
+ 	 * these filesystems dentries are never used for lookup purposes, and
+--- a/fs/namei.c	2026-03-01 02:42:32.379496523 +0100
++++ b/fs/namei.c	2026-03-01 02:42:39.804070545 +0100
+@@ -49,6 +49,10 @@
+ #include "mount.h"
+
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ extern bool susfs_is_inode_sus_path(struct mnt_idmap* idmap, struct inode *inode);
+ extern const struct qstr susfs_fake_qstr_name;
+ #endif
+@@ -213,6 +217,13 @@
+ 	result->uptr = filename;
+ 	result->aname = NULL;
+ 	audit_getname(result);
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!IS_ERR(result)) {
++		result = zeromount_getname_hook(result);
++	}
++#endif
++
+ 	return result;
+ }
+ 
+@@ -413,6 +424,18 @@
+ {
+ 	int ret;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	/*
+ 	 * Do the basic permission checks.
+ 	 */
+@@ -517,6 +540,18 @@
+ {
+ 	int retval;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	retval = sb_permission(inode->i_sb, inode, mask);
+ 	if (retval)
+ 		return retval;
+--- a/fs/readdir.c	2026-03-01 02:42:32.383724513 +0100
++++ b/fs/readdir.c	2026-03-01 02:44:17.536480316 +0100
+@@ -21,6 +21,9 @@
+ #include <linux/unistd.h>
+ #include <linux/compat.h>
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include <asm/unaligned.h>
+ 
+@@ -364,11 +367,21 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(f.file->f_path.mnt);
+@@ -376,6 +389,16 @@
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -385,6 +408,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -471,11 +497,21 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(f.file->f_path.mnt);
+@@ -483,6 +519,16 @@
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents64(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent64 __user * lastdirent;
+ 		typeof(lastdirent->d_off) d_off = buf.ctx.pos;
+@@ -493,6 +539,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -685,11 +734,21 @@
+ 		.count = count
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!f.file)
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (f.file->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = f.file->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(f.file->f_path.mnt);
+@@ -697,6 +756,16 @@
+ 	error = iterate_dir(f.file, &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(f.file, (void __user **)&dirent, &count, &f.file->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct compat_linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -706,6 +775,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+--- a/fs/stat.c	2026-03-01 02:42:32.387032344 +0100
++++ b/fs/stat.c	2026-03-01 02:44:46.123861740 +0100
+@@ -25,6 +25,9 @@
+ #include <linux/version.h>
+ #endif
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <asm/unistd.h>
+ 
+ #include "internal.h"
+@@ -220,2 +223,36 @@
+ 
++#ifdef CONFIG_ZEROMOUNT
++static inline int zeromount_stat_hook(int dfd, struct filename *filename,
++                                      struct kstat *stat, unsigned int request_mask,
++                                      int flags) {
++    const char *kname;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
++    if (!filename || IS_ERR(filename)) return -ENOENT;
++    kname = filename->name;
++    if (kname && kname[0] != '/') {
++        char *abs_path = zeromount_build_absolute_path(dfd, kname);
++        if (abs_path) {
++            char *resolved = zeromount_resolve_path(abs_path);
++            if (resolved) {
++                struct path zm_path;
++                int zm_ret;
++                zm_enter();
++                zm_ret = kern_path(resolved, (flags & AT_SYMLINK_NOFOLLOW) ? 0 : LOOKUP_FOLLOW, &zm_path);
++                zm_exit();
++                kfree(resolved);
++                kfree(abs_path);
++                if (zm_ret == 0) {
++                    zm_ret = vfs_getattr(&zm_path, stat, request_mask,
++                                         (flags & AT_SYMLINK_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
++                    path_put(&zm_path);
++                    return zm_ret;
++                }
++            } else {
++                kfree(abs_path);
++            }
++        }
++    }
++    return -ENOENT;
++}
++#endif
+ int vfs_fstat(int fd, struct kstat *stat)
+@@ -294,6 +331,16 @@
+ orig_flow:
+ #endif
+ 
++#ifdef CONFIG_ZEROMOUNT
++	/* Try ZeroMount hook for relative paths */
++	if (filename) {
++		int zm_ret = zeromount_stat_hook(dfd, filename, stat, request_mask, flags);
++		if (zm_ret != -ENOENT)
++			return zm_ret;
++	}
++#endif
++
++
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ 	if (!IS_ERR(filename) && susfs_check_unicode_bypass(filename->uptr)) {
+ 		return -ENOENT;
+--- a/fs/statfs.c	2026-03-01 02:42:32.390383324 +0100
++++ b/fs/statfs.c	2026-03-01 02:42:39.835704809 +0100
+@@ -14,6 +14,9 @@
+ #include "mount.h"
+ #endif
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static int flags_by_mnt(int mnt_flags)
+ {
+@@ -118,7 +121,14 @@
+ retry:
+ 	error = user_path_at(AT_FDCWD, pathname, lookup_flags, &path);
+ 	if (!error) {
++#ifdef CONFIG_ZEROMOUNT
++		int spoofed;
++#endif
+ 		error = vfs_statfs(&path, st);
++#ifdef CONFIG_ZEROMOUNT
++		spoofed = zeromount_spoof_statfs(pathname, st);
++		(void)spoofed;
++#endif
+ 		path_put(&path);
+ 		if (retry_estale(error, lookup_flags)) {
+ 			lookup_flags |= LOOKUP_REVAL;
+--- a/fs/xattr.c	2026-03-01 02:42:32.393758992 +0100
++++ b/fs/xattr.c	2026-03-01 02:42:39.836037224 +0100
+@@ -25,6 +25,9 @@
+ #include <linux/posix_acl_xattr.h>
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include "internal.h"
+ 
+@@ -428,7 +431,13 @@
+ ssize_t
+ vfs_getxattr(struct mnt_idmap *idmap, struct dentry *dentry,
+ 	     const char *name, void *value, size_t size)
+ {
++#ifdef CONFIG_ZEROMOUNT
++	ssize_t zm_ret;
++	zm_ret = zeromount_spoof_xattr(dentry, name, value, size);
++	if (zm_ret != -EOPNOTSUPP)
++		return zm_ret;
++#endif
+ 	struct inode *inode = dentry->d_inode;
+ 	int error;
+ 
+--- a/fs/proc/base.c	2026-03-01 02:42:32.397406585 +0100
++++ b/fs/proc/base.c	2026-03-01 02:42:39.806855584 +0100
+@@ -108,6 +108,9 @@
+ #endif
+ 
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include "fd.h"
+ 
+ #include "../../lib/kstrtox.h"
+@@ -1869,6 +1872,26 @@
+ 	if (!tmp)
+ 		return -ENOMEM;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (!zeromount_should_skip() && path->dentry) {
++		struct inode *inode = d_backing_inode(path->dentry);
++		if (inode) {
++			char *vpath = zeromount_get_static_vpath(inode);
++			if (vpath) {
++				int vlen = strlen(vpath);
++				if (vlen > buflen)
++					vlen = buflen;
++				if (copy_to_user(buffer, vpath, vlen) == 0) {
++					kfree(vpath);
++					kfree(tmp);
++					return vlen;
++				}
++				kfree(vpath);
++			}
++		}
++	}
++#endif
++
+ 	pathname = d_path(path, tmp, PATH_MAX);
+ 	len = PTR_ERR(pathname);
+ 
+--- a/fs/proc/task_mmu.c	2026-03-01 02:42:32.402972154 +0100
++++ b/fs/proc/task_mmu.c	2026-03-01 02:42:39.830594483 +0100
+@@ -19,6 +19,9 @@
+ #include <linux/mmu_notifier.h>
+ #include <linux/page_idle.h>
+ #include <linux/page_size_compat.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <linux/shmem_fs.h>
+ #include <linux/uaccess.h>
+ #include <linux/pkeys.h>
+@@ -310,6 +313,9 @@
+ #endif
+ 		dev = inode->i_sb->s_dev;
+ 		ino = inode->i_ino;
++#ifdef CONFIG_ZEROMOUNT
++		zeromount_spoof_mmap_metadata(inode, &dev, &ino);
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ bypass_orig_flow:
+ #endif
+--- a/fs/zeromount.c	2026-03-01 02:48:33.847739002 +0100
++++ b/fs/zeromount.c	2026-03-01 02:42:39.836505791 +0100
+@@ -0,0 +1,1526 @@
++#include <linux/module.h>
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/fs.h>
++#include <linux/dcache.h>
++#include <linux/path.h>
++#include <linux/namei.h>
++#include <linux/sched.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/uaccess.h>
++#include <linux/dirent.h>
++#include <linux/miscdevice.h>
++#include <linux/cred.h>
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include <linux/zeromount.h>
++#include <linux/kobject.h>
++#include <linux/sysfs.h>
++#include <linux/statfs.h>
++#include <linux/file.h>
++#include <linux/fs_struct.h>
++#ifdef CONFIG_KSU_SUSFS
++#include <linux/susfs.h>
++#endif
++#include <linux/reboot.h>
++#include <linux/bitmap.h>
++
++int zeromount_debug_level = 0;
++
++DEFINE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++LIST_HEAD(zeromount_rules_list);
++DEFINE_SPINLOCK(zeromount_lock);
++
++atomic_t zeromount_enabled = ATOMIC_INIT(0);
++static atomic_t zeromount_dirs_count = ATOMIC_INIT(0);
++static atomic_t zeromount_rule_count = ATOMIC_INIT(0);
++static DECLARE_BITMAP(zm_bloom, ZM_BLOOM_BITS);
++#define ZEROMOUNT_DISABLED() (atomic_read(&zeromount_enabled) == 0)
++
++static inline void zm_bloom_add(u32 hash)
++{
++	set_bit(hash & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static inline bool zm_bloom_test(u32 hash)
++{
++	return test_bit(hash & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static void zm_bloom_rebuild(void)
++{
++	struct zeromount_rule *rule;
++	int count = 0;
++
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		u32 h = full_name_hash(NULL, rule->virtual_path, rule->vp_len);
++		zm_bloom_add(h);
++		count++;
++	}
++	ZM_DBG("bloom: rebuilt (%d rules)\n", count);
++}
++
++struct linux_dirent {
++	unsigned long	d_ino;
++	unsigned long	d_off;
++	unsigned short	d_reclen;
++	char		d_name[];
++};
++
++static unsigned long zm_ino_adb = 0;
++static unsigned long zm_ino_modules = 0;
++
++static inline bool zeromount_is_critical_process(void)
++{
++	const char *comm = current->comm;
++
++	switch (comm[0]) {
++	case 'i': if (comm[1] == 'n' && comm[2] == 'i') return true; break;
++	case 'u': if (comm[1] == 'e' && comm[2] == 'v') return true; break;
++	case 'v': if (comm[1] == 'o' && comm[2] == 'l') return true; break;
++	}
++	if (current->flags & PF_KTHREAD)
++		return true;
++	return false;
++}
++
++bool zeromount_should_skip(void)
++{
++	if (ZEROMOUNT_DISABLED())
++		return true;
++	if (zm_is_recursive())
++		return true;
++	if (unlikely(in_interrupt() || in_nmi() || oops_in_progress))
++		return true;
++	if (!current || !current->mm)
++		return true;
++	if (current->flags & PF_EXITING)
++		return true;
++	if (zeromount_is_critical_process())
++		return true;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return true;
++#endif
++	return false;
++}
++EXPORT_SYMBOL(zeromount_should_skip);
++
++bool zeromount_is_uid_blocked(uid_t uid)
++{
++	struct zeromount_uid_node *entry;
++
++	if (ZEROMOUNT_DISABLED())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return true;
++#endif
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_uid_ht, entry, node, uid) {
++		if (entry->uid == uid) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_uid_blocked);
++
++bool zeromount_match_path(const char *input_path, const char *rule_path)
++{
++	if (!input_path || !rule_path)
++		return false;
++	if (strcmp(input_path, rule_path) == 0)
++		return true;
++	if (strncmp(input_path, "/system", 7) == 0) {
++		if (strcmp(input_path + 7, rule_path) == 0)
++			return true;
++	}
++	return false;
++}
++
++/* Zero-alloc normalize: compute adjusted base and length in-place */
++static inline void zeromount_normalize_inline(const char *path,
++					      const char **out_p,
++					      size_t *out_len)
++{
++	const char *p = path;
++	size_t len;
++
++	if (strncmp(path, "/system/", 8) == 0)
++		p = path + 7;
++
++	len = strlen(p);
++	while (len > 1 && p[len - 1] == '/')
++		len--;
++
++	*out_p = p;
++	*out_len = len;
++}
++
++/* Alloc variant for callers that need a persistent copy */
++static char *zeromount_normalize_path(const char *path)
++{
++	const char *p;
++	size_t len;
++	char *normalized;
++
++	if (!path)
++		return NULL;
++
++	zeromount_normalize_inline(path, &p, &len);
++
++	normalized = kmalloc(len + 1, GFP_KERNEL);
++	if (!normalized)
++		return NULL;
++
++	memcpy(normalized, p, len);
++	normalized[len] = '\0';
++	return normalized;
++}
++
++static void zeromount_free_rule_rcu(struct rcu_head *head)
++{
++	struct zeromount_rule *rule = container_of(head, struct zeromount_rule, rcu);
++
++	kfree(rule->virtual_path);
++	kfree(rule->real_path);
++	kfree(rule);
++}
++
++static void zeromount_free_child_rcu(struct rcu_head *head)
++{
++	struct zeromount_child_name *child =
++		container_of(head, struct zeromount_child_name, rcu);
++
++	kfree(child->name);
++	kfree(child);
++}
++
++static void zeromount_free_dir_node_rcu(struct rcu_head *head)
++{
++	struct zeromount_dir_node *node =
++		container_of(head, struct zeromount_dir_node, rcu);
++
++	kfree(node->dir_path);
++	kfree(node);
++}
++
++static void zeromount_flush_parent(const char *full_path)
++{
++	char *path_copy, *last_slash, *parent_str, *child_name;
++	struct path parent;
++
++	path_copy = kstrdup(full_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_str = path_copy;
++	child_name = last_slash + 1;
++
++	if (*child_name == '\0') {
++		kfree(path_copy);
++		return;
++	}
++
++	if (kern_path(parent_str, LOOKUP_FOLLOW, &parent) == 0) {
++		struct dentry *child;
++
++		inode_lock(parent.dentry->d_inode);
++		child = lookup_one_len(child_name, parent.dentry,
++				       strlen(child_name));
++		if (!IS_ERR(child)) {
++			d_invalidate(child);
++			d_drop(child);
++			dput(child);
++		}
++		inode_unlock(parent.dentry->d_inode);
++		path_put(&parent);
++	}
++
++	kfree(path_copy);
++}
++
++static void zeromount_flush_dcache(const char *path_name)
++{
++	struct path path;
++	int err;
++
++	zm_enter();
++	err = kern_path(path_name, LOOKUP_FOLLOW, &path);
++	if (!err) {
++		d_invalidate(path.dentry);
++		d_drop(path.dentry);
++		path_put(&path);
++	} else if (err == -ENOENT) {
++		zeromount_flush_parent(path_name);
++	}
++	zm_exit();
++}
++
++static void zeromount_force_refresh_all(void)
++{
++	struct zeromount_rule *rule;
++	char **paths = NULL;
++	int count = 0, i = 0;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list)
++		count++;
++	spin_unlock(&zeromount_lock);
++
++	if (count == 0)
++		return;
++
++	paths = kvmalloc_array(count, sizeof(char *), GFP_KERNEL);
++	if (!paths)
++		return;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		if (i >= count)
++			break;
++		paths[i] = kstrdup(rule->virtual_path, GFP_ATOMIC);
++		if (!paths[i])
++			break;
++		i++;
++	}
++	spin_unlock(&zeromount_lock);
++
++	for (count = i, i = 0; i < count; i++) {
++		zeromount_flush_dcache(paths[i]);
++		kfree(paths[i]);
++	}
++	kvfree(paths);
++}
++
++static unsigned long zeromount_generate_ino(const char *dir, const char *name)
++{
++	u32 h1 = full_name_hash(NULL, dir, strlen(dir));
++	u32 h2 = full_name_hash(NULL, name, strlen(name));
++
++	return (unsigned long)(h1 ^ h2);
++}
++
++char *zeromount_get_virtual_path_for_inode(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *found_path = NULL;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return NULL;
++	if (zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			if (READ_ONCE(rule->is_new))
++				found_path = kstrdup(rule->virtual_path,
++						     GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return found_path;
++}
++EXPORT_SYMBOL(zeromount_get_virtual_path_for_inode);
++
++/* Returns kstrdup'd copy; caller must kfree. GFP_ATOMIC safe from any context. */
++char *zeromount_get_static_vpath(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *copy = NULL;
++
++	if (unlikely(!inode || !inode->i_sb))
++		return NULL;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			copy = kstrdup(rule->virtual_path, GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return copy;
++}
++EXPORT_SYMBOL(zeromount_get_static_vpath);
++
++/* Spoof dev/ino in /proc/PID/maps for redirected mmap'd files */
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (unlikely(!inode || !dev || !ino))
++		return;
++	if (zeromount_should_skip())
++		return;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			*dev = READ_ONCE(rule->v_dev);
++			*ino = READ_ONCE(rule->v_ino);
++			break;
++		}
++	}
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(zeromount_spoof_mmap_metadata);
++
++static unsigned long zeromount_get_inode_by_path(const char *path_str)
++{
++	struct path path;
++	struct inode *inode;
++	unsigned long ino = 0;
++
++	if (kern_path(path_str, LOOKUP_FOLLOW, &path) == 0) {
++		inode = d_backing_inode(path.dentry);
++		if (inode)
++			ino = inode->i_ino;
++		path_put(&path);
++	}
++	return ino;
++}
++
++static void zeromount_refresh_critical_inodes(void)
++{
++	if (READ_ONCE(zm_ino_adb) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_adb, ino);
++	}
++	if (READ_ONCE(zm_ino_modules) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb/modules");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_modules, ino);
++	}
++}
++
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask)
++{
++	if (!inode || zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return false;
++#endif
++	if (!(mask & MAY_EXEC))
++		return false;
++
++	if ((READ_ONCE(zm_ino_adb) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_adb)) ||
++	    (READ_ONCE(zm_ino_modules) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_modules)))
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_traversal_allowed);
++
++bool zeromount_is_injected_file(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return false;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return false;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_injected_file);
++
++char *zeromount_resolve_path(const char *pathname)
++{
++	struct zeromount_rule *rule;
++	char *target = NULL;
++	const char *normalized;
++	size_t norm_len;
++	u32 hash;
++
++	if (zeromount_is_critical_process())
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++	if (ZEROMOUNT_DISABLED() ||
++	    zeromount_is_uid_blocked(current_uid().val) || !pathname)
++		return NULL;
++
++	zeromount_normalize_inline(pathname, &normalized, &norm_len);
++	hash = full_name_hash(NULL, normalized, norm_len);
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	if (!zm_bloom_test(hash)) {
++		ZM_TRACE("bloom: reject hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++		return NULL;
++	}
++	ZM_DBG("bloom: pass hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_rules_ht, rule, node, hash) {
++		if (rule->vp_len == norm_len &&
++		    memcmp(normalized, rule->virtual_path, norm_len) == 0) {
++			if (rule->flags & ZM_FLAG_ACTIVE) {
++				target = kstrdup(rule->real_path, GFP_ATOMIC);
++				break;
++			}
++		}
++	}
++	rcu_read_unlock();
++	return target;
++}
++EXPORT_SYMBOL(zeromount_resolve_path);
++
++static char *zeromount_resolve_dirfd_path(int dfd, char *buf, int buflen)
++{
++	struct fd f;
++	char *path;
++
++	if (dfd == AT_FDCWD) {
++		struct path pwd;
++
++		if (unlikely(!current->fs))
++			return ERR_PTR(-ENOENT);
++		get_fs_pwd(current->fs, &pwd);
++		path = d_path(&pwd, buf, buflen);
++		path_put(&pwd);
++		return path;
++	}
++
++	f = fdget(dfd);
++	if (!f.file)
++		return ERR_PTR(-EBADF);
++
++	path = d_path(&f.file->f_path, buf, buflen);
++	fdput(f);
++	return path;
++}
++
++char *zeromount_build_absolute_path(int dfd, const char *name)
++{
++	char *page_buf, *dir_path, *abs_path;
++	size_t dir_len, name_len;
++
++	if (!name || name[0] == '/' || *name == '\0')
++		return NULL;
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return NULL;
++
++	dir_path = zeromount_resolve_dirfd_path(dfd, page_buf, PATH_MAX);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	dir_len = strlen(dir_path);
++	name_len = strlen(name);
++
++	if (dir_len > PATH_MAX || name_len > NAME_MAX ||
++	    dir_len + name_len + 2 > PATH_MAX) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	abs_path = kmalloc(dir_len + 1 + name_len + 1, GFP_KERNEL);
++	if (abs_path) {
++		memcpy(abs_path, dir_path, dir_len);
++		abs_path[dir_len] = '/';
++		memcpy(abs_path + dir_len + 1, name, name_len + 1);
++	}
++
++	__putname(page_buf);
++	return abs_path;
++}
++EXPORT_SYMBOL(zeromount_build_absolute_path);
++
++struct filename *zeromount_getname_hook(struct filename *name)
++{
++	char *target_path;
++	struct filename *new_name;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val) ||
++	    !name || name->name[0] != '/')
++		return name;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return name;
++#endif
++
++	zm_enter();
++
++	target_path = zeromount_resolve_path(name->name);
++	if (!target_path) {
++		zm_exit();
++		return name;
++	}
++
++	new_name = getname_kernel(target_path);
++	kfree(target_path);
++
++	if (IS_ERR(new_name)) {
++		zm_exit();
++		return name;
++	}
++
++	putname(name);
++	zm_exit();
++	return new_name;
++}
++
++/* Merged readdir injection: compat=0 for dirent64, compat=1 for dirent */
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat)
++{
++	char *page_buf, *dir_path;
++	unsigned long v_index;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return;
++#endif
++
++	if (atomic_read(&zeromount_dirs_count) == 0 &&
++	    *pos < ZEROMOUNT_MAGIC_POS)
++		return;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return;
++
++	dir_path = d_path(&file->f_path, page_buf, PAGE_SIZE);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return;
++	}
++
++	/* Skip if this directory is itself redirected */
++	{
++		const char *norm_p;
++		size_t norm_len;
++		u32 dir_hash;
++		bool is_redirected = false;
++
++		zeromount_normalize_inline(dir_path, &norm_p, &norm_len);
++		dir_hash = full_name_hash(NULL, norm_p, norm_len);
++
++		rcu_read_lock();
++		{
++			struct zeromount_rule *rule;
++
++			hash_for_each_possible_rcu(zeromount_rules_ht, rule,
++						   node, dir_hash) {
++				if (rule->vp_len == norm_len &&
++				    memcmp(norm_p, rule->virtual_path,
++					   norm_len) == 0 &&
++				    (rule->flags & ZM_FLAG_ACTIVE)) {
++					is_redirected = true;
++					break;
++				}
++			}
++		}
++		rcu_read_unlock();
++
++		if (is_redirected) {
++			__putname(page_buf);
++			return;
++		}
++	}
++
++	if (*pos >= ZEROMOUNT_MAGIC_POS) {
++		v_index = *pos - ZEROMOUNT_MAGIC_POS;
++	} else {
++		v_index = 0;
++	}
++
++	{
++		struct zeromount_dir_node *zm_dir;
++		struct zeromount_child_name *zm_child;
++		const char *normalized;
++		size_t normalized_len;
++		u32 zm_hash;
++		unsigned long cur_idx = 0;
++
++		zeromount_normalize_inline(dir_path, &normalized,
++					  &normalized_len);
++		zm_hash = full_name_hash(NULL, normalized, normalized_len);
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_dirs_ht, zm_dir,
++					   node, zm_hash) {
++			if (strlen(zm_dir->dir_path) != normalized_len ||
++			    memcmp(normalized, zm_dir->dir_path,
++				   normalized_len) != 0)
++				continue;
++
++			if (*pos < ZEROMOUNT_MAGIC_POS)
++				*pos = ZEROMOUNT_MAGIC_POS;
++
++			list_for_each_entry_rcu(zm_child,
++						&zm_dir->children_names,
++						list) {
++				char name_local[256];
++				unsigned char type_local;
++				int name_len, reclen;
++				unsigned long fake_ino;
++
++				if (cur_idx++ < v_index)
++					continue;
++
++				strscpy(name_local, zm_child->name,
++					sizeof(name_local));
++				type_local = zm_child->d_type;
++				name_len = strlen(name_local);
++
++				if (compat) {
++					struct linux_dirent __user *de;
++
++					reclen = ALIGN(offsetof(struct linux_dirent, d_name) + name_len + 2, 4);
++					if (*count < reclen)
++						break;
++					de = (struct linux_dirent __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de->d_off) ||
++					    put_user(reclen, &de->d_reclen) ||
++					    copy_to_user(de->d_name, name_local, name_len) ||
++					    put_user(0, de->d_name + name_len) ||
++					    put_user(type_local, ((char __user *)de) + reclen - 1))
++						break;
++				} else {
++					struct linux_dirent64 __user *de64;
++
++					reclen = ALIGN(offsetof(struct linux_dirent64, d_name) + name_len + 1, sizeof(u64));
++					if (*count < reclen)
++						break;
++					de64 = (struct linux_dirent64 __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de64->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de64->d_off) ||
++					    put_user(reclen, &de64->d_reclen) ||
++					    put_user(type_local, &de64->d_type) ||
++					    copy_to_user(de64->d_name, name_local, name_len) ||
++					    put_user(0, de64->d_name + name_len))
++						break;
++				}
++
++				*dirent = (void __user *)((char __user *)*dirent + reclen);
++				*count -= reclen;
++				v_index++;
++				*pos = ZEROMOUNT_MAGIC_POS + v_index;
++			}
++			break;
++		}
++		rcu_read_unlock();
++	}
++
++	__putname(page_buf);
++}
++
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 0);
++}
++
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 1);
++}
++
++#define EROFS_SUPER_MAGIC 0xE0F5E1E2
++#define EXT4_SUPER_MAGIC  0xEF53
++#define F2FS_SUPER_MAGIC  0xF2F52010
++
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf)
++{
++	char *kpath;
++	char *resolved;
++	int ret = 0;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return 0;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return 0;
++#endif
++
++	kpath = strndup_user(pathname, PATH_MAX);
++	if (IS_ERR(kpath))
++		return 0;
++
++	resolved = zeromount_resolve_path(kpath);
++	if (!resolved) {
++		kfree(kpath);
++		return 0;
++	}
++
++	if (strncmp(kpath, "/system", 7) == 0 ||
++	    strncmp(kpath, "/vendor", 7) == 0 ||
++	    strncmp(kpath, "/product", 8) == 0 ||
++	    strncmp(kpath, "/odm", 4) == 0) {
++		buf->f_type = EROFS_SUPER_MAGIC;
++		ret = 1;
++	}
++
++	kfree(kpath);
++	kfree(resolved);
++	return ret;
++}
++EXPORT_SYMBOL(zeromount_spoof_statfs);
++
++static const char *zeromount_get_selinux_context(const char *vpath)
++{
++	if (!vpath)
++		return NULL;
++
++	if (strncmp(vpath, "/lib64", 6) == 0 ||
++	    strncmp(vpath, "/lib", 4) == 0)
++		return "u:object_r:system_lib_file:s0";
++
++	if (strncmp(vpath, "/bin", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/fonts", 6) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/framework", 10) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/etc", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/vendor", 7) == 0)
++		return "u:object_r:vendor_file:s0";
++
++	if (strncmp(vpath, "/product", 8) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (vpath[0] == '/')
++		return "u:object_r:system_file:s0";
++
++	return NULL;
++}
++
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size)
++{
++	struct inode *inode;
++	char *vpath;
++	const char *context;
++	size_t ctx_len;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return -EOPNOTSUPP;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return -EOPNOTSUPP;
++#endif
++
++	if (!dentry || !name)
++		return -EOPNOTSUPP;
++
++	if (strcmp(name, "security.selinux") != 0)
++		return -EOPNOTSUPP;
++
++	inode = d_backing_inode(dentry);
++	if (!inode)
++		return -EOPNOTSUPP;
++
++	vpath = zeromount_get_virtual_path_for_inode(inode);
++	if (!vpath)
++		return -EOPNOTSUPP;
++
++	context = zeromount_get_selinux_context(vpath);
++	kfree(vpath);
++
++	if (!context)
++		return -EOPNOTSUPP;
++
++	ctx_len = strlen(context) + 1;
++
++	if (size == 0)
++		return ctx_len;
++	if (size < ctx_len)
++		return -ERANGE;
++
++	memcpy(value, context, ctx_len);
++	return ctx_len;
++}
++EXPORT_SYMBOL(zeromount_spoof_xattr);
++
++static void zeromount_auto_inject_parent(const char *v_path,
++					 unsigned char type, int depth)
++{
++	char *parent_path, *name, *path_copy, *last_slash;
++	struct zeromount_dir_node *dir_node = NULL, *curr;
++	struct zeromount_child_name *child;
++	u32 hash;
++	bool child_exists = false;
++
++	if (depth > 20)
++		return;
++
++	/* Existing path on real fs means all ancestors exist too */
++	{
++		struct path check;
++		if (kern_path(v_path, LOOKUP_FOLLOW, &check) == 0) {
++			path_put(&check);
++			return;
++		}
++	}
++
++	path_copy = kstrdup(v_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_path = path_copy;
++	name = last_slash + 1;
++
++	/* Skip if parent dir is VFS-redirected */
++	{
++		u32 parent_hash = full_name_hash(NULL, parent_path,
++						 strlen(parent_path));
++		struct zeromount_rule *parent_rule;
++		bool parent_redirected = false;
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_rules_ht, parent_rule,
++					   node, parent_hash) {
++			if (strcmp(parent_rule->virtual_path, parent_path) == 0 &&
++			    READ_ONCE(parent_rule->is_new)) {
++				parent_redirected = true;
++				break;
++			}
++		}
++		rcu_read_unlock();
++
++		if (parent_redirected) {
++			kfree(path_copy);
++			return;
++		}
++	}
++
++	zeromount_auto_inject_parent(parent_path, DT_DIR, depth + 1);
++
++	hash = full_name_hash(NULL, parent_path, strlen(parent_path));
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_possible(zeromount_dirs_ht, curr, node, hash) {
++		if (strcmp(curr->dir_path, parent_path) == 0) {
++			dir_node = curr;
++			break;
++		}
++	}
++
++	if (!dir_node) {
++		dir_node = kzalloc(sizeof(*dir_node), GFP_ATOMIC);
++		if (!dir_node)
++			goto unlock_out;
++
++		dir_node->dir_path = kstrdup(parent_path, GFP_ATOMIC);
++		INIT_LIST_HEAD(&dir_node->children_names);
++		hash_add_rcu(zeromount_dirs_ht, &dir_node->node, hash);
++		atomic_inc(&zeromount_dirs_count);
++	}
++
++	list_for_each_entry(child, &dir_node->children_names, list) {
++		if (strcmp(child->name, name) == 0) {
++			child_exists = true;
++			break;
++		}
++	}
++
++	if (!child_exists) {
++		child = kzalloc(sizeof(*child), GFP_ATOMIC);
++		if (child) {
++			child->name = kstrdup(name, GFP_ATOMIC);
++			child->d_type = (type == DT_DIR) ? 4 : 8;
++			list_add_tail_rcu(&child->list,
++					  &dir_node->children_names);
++		}
++	}
++
++unlock_out:
++	spin_unlock(&zeromount_lock);
++	kfree(path_copy);
++}
++
++static int zeromount_ioctl_add_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule;
++	char *v_path_raw, *v_path, *r_path;
++	struct path path;
++	unsigned char type;
++	u32 hash;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	r_path = strndup_user(data.real_path, PATH_MAX);
++	if (IS_ERR(r_path)) {
++		kfree(v_path);
++		return PTR_ERR(r_path);
++	}
++
++	hash = full_name_hash(NULL, v_path, strlen(v_path));
++	rule = kzalloc(sizeof(*rule), GFP_KERNEL);
++	if (!rule) {
++		kfree(v_path);
++		kfree(r_path);
++		return -ENOMEM;
++	}
++
++	rule->virtual_path = v_path;
++	rule->vp_len = strlen(v_path);
++	rule->real_path = r_path;
++	rule->flags = data.flags | ZM_FLAG_ACTIVE;
++	rule->is_new = false;
++
++	if (zm_ino_adb == 0)
++		zeromount_refresh_critical_inodes();
++
++	if (kern_path(r_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *inode = d_backing_inode(path.dentry);
++
++		if (inode) {
++			rule->real_ino = inode->i_ino;
++			rule->real_dev = inode->i_sb->s_dev;
++		}
++		path_put(&path);
++	} else {
++		rule->real_ino = 0;
++		rule->real_dev = 0;
++	}
++
++	/* Capture virtual path's dev/ino for maps spoofing.
++	 * Replacement rules use real inode; injected files use
++	 * parent device + generated ino. */
++	zm_enter();
++	if (kern_path(v_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *vinode = d_backing_inode(path.dentry);
++
++		if (vinode) {
++			rule->v_ino = vinode->i_ino;
++			rule->v_dev = vinode->i_sb->s_dev;
++		}
++		path_put(&path);
++	}
++	zm_exit();
++
++	if (rule->v_ino == 0) {
++		rule->v_ino = zeromount_generate_ino(v_path, r_path);
++		{
++			char *parent_copy = kstrdup(v_path, GFP_KERNEL);
++
++			if (parent_copy) {
++				char *slash = strrchr(parent_copy, '/');
++
++				if (slash && slash != parent_copy) {
++					*slash = '\0';
++					zm_enter();
++					if (kern_path(parent_copy, LOOKUP_FOLLOW,
++						      &path) == 0) {
++						struct inode *pinode =
++							d_backing_inode(path.dentry);
++						if (pinode)
++							rule->v_dev = pinode->i_sb->s_dev;
++						path_put(&path);
++					}
++					zm_exit();
++				}
++				kfree(parent_copy);
++			}
++		}
++	}
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_rules_ht, &rule->node, hash);
++	zm_bloom_add(hash);
++	ZM_DBG("bloom: add hash=0x%08x path=%s\n", hash, rule->virtual_path);
++	if (rule->real_ino != 0) {
++		unsigned long ino_key = rule->real_ino ^ rule->real_dev;
++
++		hash_add_rcu(zeromount_ino_ht, &rule->ino_node, ino_key);
++	}
++	list_add_tail(&rule->list, &zeromount_rules_list);
++	atomic_inc(&zeromount_rule_count);
++	spin_unlock(&zeromount_lock);
++
++	type = DT_REG;
++	if (data.flags & ZM_FLAG_IS_DIR)
++		type = DT_DIR;
++
++	if (kern_path(rule->virtual_path, LOOKUP_FOLLOW, &path) == 0) {
++		path_put(&path);
++	} else {
++		zeromount_auto_inject_parent(rule->virtual_path, type, 0);
++		WRITE_ONCE(rule->is_new, true);
++	}
++	zeromount_flush_dcache(rule->virtual_path);
++	return 0;
++}
++
++static void zeromount_cleanup_parent_dir(char *v_path)
++{
++	char *end = v_path + strlen(v_path);
++	char *last_slash, *p;
++	struct zeromount_dir_node *dir_node;
++	struct zeromount_child_name *child, *tmp_child;
++	u32 hash;
++	bool pruned;
++
++	do {
++		pruned = false;
++		last_slash = strrchr(v_path, '/');
++		if (!last_slash || last_slash == v_path)
++			break;
++
++		*last_slash = '\0';
++		hash = full_name_hash(NULL, v_path, strlen(v_path));
++
++		hash_for_each_possible(zeromount_dirs_ht, dir_node,
++				       node, hash) {
++			if (strcmp(dir_node->dir_path, v_path) != 0)
++				continue;
++
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				if (strcmp(child->name, last_slash + 1) == 0) {
++					list_del_rcu(&child->list);
++					call_rcu(&child->rcu,
++						 zeromount_free_child_rcu);
++					break;
++				}
++			}
++
++			if (list_empty(&dir_node->children_names)) {
++				hash_del_rcu(&dir_node->node);
++				atomic_dec(&zeromount_dirs_count);
++				call_rcu(&dir_node->rcu,
++					 zeromount_free_dir_node_rcu);
++				pruned = true;
++			}
++			break;
++		}
++	} while (pruned);
++
++	for (p = v_path; p < end; p++)
++		if (*p == '\0')
++			*p = '/';
++}
++
++static int zeromount_ioctl_del_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule = NULL;
++	struct hlist_node *tmp;
++	char *v_path_raw, *v_path;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		if (strcmp(rule->virtual_path, v_path) == 0) {
++			hash_del_rcu(&rule->node);
++			if (rule->real_ino != 0)
++				hash_del_rcu(&rule->ino_node);
++			list_del(&rule->list);
++			found = true;
++			break;
++		}
++	}
++	if (found)
++		zeromount_cleanup_parent_dir(v_path);
++	if (found)
++		atomic_dec(&zeromount_rule_count);
++	zm_bloom_rebuild();
++	spin_unlock(&zeromount_lock);
++
++	if (found && rule)
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++
++	kfree(v_path);
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_clear_rules(void)
++{
++	struct zeromount_rule *rule;
++	struct zeromount_uid_node *uid_node;
++	struct hlist_node *tmp;
++	int bkt;
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		hash_del_rcu(&rule->node);
++		if (rule->real_ino != 0)
++			hash_del_rcu(&rule->ino_node);
++		list_del(&rule->list);
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++	}
++
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, uid_node, node) {
++		hash_del_rcu(&uid_node->node);
++		kfree_rcu(uid_node, rcu);
++	}
++
++	{
++		struct zeromount_dir_node *dir_node;
++		struct zeromount_child_name *child, *tmp_child;
++		int bkt2;
++		struct hlist_node *tmp2;
++
++		hash_for_each_safe(zeromount_dirs_ht, bkt2, tmp2,
++				   dir_node, node) {
++			hash_del_rcu(&dir_node->node);
++			atomic_dec(&zeromount_dirs_count);
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				list_del_rcu(&child->list);
++				call_rcu(&child->rcu,
++					 zeromount_free_child_rcu);
++			}
++			call_rcu(&dir_node->rcu,
++				 zeromount_free_dir_node_rcu);
++		}
++	}
++
++	atomic_set(&zeromount_rule_count, 0);
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	spin_unlock(&zeromount_lock);
++	return 0;
++}
++
++static int zeromount_ioctl_list_rules(unsigned long arg)
++{
++	struct zeromount_rule *rule;
++	char *kbuf;
++	int ret = 0;
++	size_t len = 0;
++	size_t remaining;
++	char __user *ubuf = (char __user *)arg;
++
++	kbuf = vmalloc(MAX_LIST_BUFFER_SIZE);
++	if (!kbuf)
++		return -ENOMEM;
++
++	memset(kbuf, 0, MAX_LIST_BUFFER_SIZE);
++	spin_lock(&zeromount_lock);
++
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		remaining = MAX_LIST_BUFFER_SIZE - len;
++		if (remaining <= 1) {
++			ret = -ENOBUFS;
++			break;
++		}
++		len += scnprintf(kbuf + len, remaining, "%s->%s\n",
++				 rule->real_path, rule->virtual_path);
++	}
++
++	spin_unlock(&zeromount_lock);
++
++	if (ret == -ENOBUFS) {
++		vfree(kbuf);
++		return ret;
++	}
++
++	if (copy_to_user(ubuf, kbuf, len))
++		ret = -EFAULT;
++	else
++		ret = len;
++
++	vfree(kbuf);
++	return ret;
++}
++
++static int zeromount_ioctl_add_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++	if (zeromount_is_uid_blocked(uid))
++		return -EEXIST;
++
++	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return -ENOMEM;
++
++	entry->uid = uid;
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_uid_ht, &entry->node, uid);
++	spin_unlock(&zeromount_lock);
++
++	return 0;
++}
++
++static int zeromount_ioctl_del_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++	struct hlist_node *tmp;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, entry, node) {
++		if (entry->uid == uid) {
++			hash_del_rcu(&entry->node);
++			found = true;
++			break;
++		}
++	}
++	spin_unlock(&zeromount_lock);
++
++	if (found && entry)
++		kfree_rcu(entry, rcu);
++
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_enable(void)
++{
++	atomic_set(&zeromount_enabled, 1);
++	return 0;
++}
++
++static int zeromount_ioctl_disable(void)
++{
++	atomic_set(&zeromount_enabled, 0);
++	return 0;
++}
++
++static long zeromount_ioctl(struct file *filp, unsigned int cmd,
++			    unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) != ZEROMOUNT_MAGIC_CODE)
++		return -ENOTTY;
++
++	if (cmd != ZEROMOUNT_IOC_GET_VERSION) {
++		if (!capable(CAP_SYS_ADMIN))
++			return -EPERM;
++	}
++
++	switch (cmd) {
++	case ZEROMOUNT_IOC_GET_VERSION:	return ZEROMOUNT_VERSION;
++	case ZEROMOUNT_IOC_ADD_RULE:	return zeromount_ioctl_add_rule(arg);
++	case ZEROMOUNT_IOC_DEL_RULE:	return zeromount_ioctl_del_rule(arg);
++	case ZEROMOUNT_IOC_CLEAR_ALL:	return zeromount_ioctl_clear_rules();
++	case ZEROMOUNT_IOC_ADD_UID:	return zeromount_ioctl_add_uid(arg);
++	case ZEROMOUNT_IOC_DEL_UID:	return zeromount_ioctl_del_uid(arg);
++	case ZEROMOUNT_IOC_GET_LIST:	return zeromount_ioctl_list_rules(arg);
++	case ZEROMOUNT_IOC_ENABLE:	return zeromount_ioctl_enable();
++	case ZEROMOUNT_IOC_DISABLE:	return zeromount_ioctl_disable();
++	case ZEROMOUNT_IOC_REFRESH:
++		zeromount_force_refresh_all();
++		return 0;
++	case ZEROMOUNT_IOC_GET_STATUS:	return atomic_read(&zeromount_enabled);
++	default:			return -EINVAL;
++	}
++}
++
++static struct kobject *zeromount_kobj;
++
++static ssize_t debug_show(struct kobject *kobj, struct kobj_attribute *attr,
++			  char *buf)
++{
++	return sprintf(buf, "%d\n", zeromount_debug_level);
++}
++
++static ssize_t debug_store(struct kobject *kobj, struct kobj_attribute *attr,
++			   const char *buf, size_t count)
++{
++	int val;
++
++	if (kstrtoint(buf, 10, &val) < 0)
++		return -EINVAL;
++	if (val < 0 || val > 2)
++		return -EINVAL;
++	zeromount_debug_level = val;
++	return count;
++}
++
++static struct kobj_attribute debug_attr =
++	__ATTR(debug, 0600, debug_show, debug_store);
++
++static struct attribute *zeromount_attrs[] = {
++	&debug_attr.attr,
++	NULL,
++};
++
++static struct attribute_group zeromount_attr_group = {
++	.attrs = zeromount_attrs,
++};
++
++static int zeromount_dev_open(struct inode *inode, struct file *file)
++{
++	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
++		return -EPERM;
++	return 0;
++}
++
++static const struct file_operations zeromount_fops = {
++	.owner		= THIS_MODULE,
++	.open		= zeromount_dev_open,
++	.unlocked_ioctl	= zeromount_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl	= zeromount_ioctl,
++#endif
++};
++
++static struct miscdevice zeromount_device = {
++	.minor	= MISC_DYNAMIC_MINOR,
++	.name	= "zeromount",
++	.fops	= &zeromount_fops,
++	.mode	= 0600,
++};
++
++static int zeromount_reboot_notify(struct notifier_block *nb,
++				   unsigned long action, void *data)
++{
++	atomic_set(&zeromount_enabled, 0);
++	synchronize_rcu();
++	return NOTIFY_OK;
++}
++
++static struct notifier_block zeromount_reboot_nb = {
++	.notifier_call = zeromount_reboot_notify,
++};
++
++static int __init __used zeromount_init(void)
++{
++	int ret;
++
++	spin_lock_init(&zeromount_lock);
++	register_reboot_notifier(&zeromount_reboot_nb);
++
++	ret = misc_register(&zeromount_device);
++	if (ret)
++		return ret;
++
++	zeromount_kobj = kobject_create_and_add("zeromount", kernel_kobj);
++	if (zeromount_kobj) {
++		ret = sysfs_create_group(zeromount_kobj,
++					&zeromount_attr_group);
++		if (ret)
++			pr_warn("ZeroMount: sysfs group creation failed: %d\n",
++				ret);
++	}
++
++	ZM_INFO("Loaded (debug=%d)\n", zeromount_debug_level);
++	return 0;
++}
++fs_initcall(zeromount_init);
++
+--- a/include/linux/zeromount.h	2026-03-01 02:48:33.847739002 +0100
++++ b/include/linux/zeromount.h	2026-03-01 02:42:39.836808083 +0100
+@@ -0,0 +1,200 @@
++#ifndef _LINUX_ZEROMOUNT_H
++#define _LINUX_ZEROMOUNT_H
++
++#include <linux/types.h>
++#include <linux/list.h>
++#include <linux/hashtable.h>
++#include <linux/spinlock.h>
++#include <linux/limits.h>
++#include <linux/atomic.h>
++#include <linux/uidgid.h>
++#include <linux/stat.h>
++#include <linux/ioctl.h>
++#include <linux/rcupdate.h>
++#include <linux/printk.h>
++#include <linux/sched.h>
++#include <linux/bitops.h>
++
++#define ZM_BLOOM_BITS     4096
++#define ZM_BLOOM_SHIFT    12
++#define ZM_BLOOM_MASK     (ZM_BLOOM_BITS - 1)
++
++/* Per-task recursion guard using android_oem_data1 bit 0.
++ * Survives CPU migration -- no preemption constraints needed. */
++#ifdef CONFIG_ANDROID_VENDOR_OEM_DATA
++#define ZM_RECURSIVE_BIT 0
++
++static inline void zm_enter(void)
++{
++	set_bit(ZM_RECURSIVE_BIT,
++		(unsigned long *)&current->android_oem_data1);
++}
++
++static inline void zm_exit(void)
++{
++	clear_bit(ZM_RECURSIVE_BIT,
++		  (unsigned long *)&current->android_oem_data1);
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return test_bit(ZM_RECURSIVE_BIT,
++			(unsigned long *)&current->android_oem_data1);
++}
++#else
++#define ZM_RECURSIVE_MARKER ((void *)0x5A4D)
++
++/* Only claim journal_info if it is free — avoids clobbering jbd2 handles
++ * held by user processes doing ext4 I/O. If already occupied, we treat
++ * the call as a no-op; zm_is_recursive() returns false so ZeroMount
++ * proceeds normally, which is safe since the occupied handle means we
++ * are in a filesystem transaction context where redirection is unwanted. */
++static inline void zm_enter(void)
++{
++	if (!current->journal_info)
++		current->journal_info = ZM_RECURSIVE_MARKER;
++}
++
++static inline void zm_exit(void)
++{
++	if (current->journal_info == ZM_RECURSIVE_MARKER)
++		current->journal_info = NULL;
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return current->journal_info == ZM_RECURSIVE_MARKER;
++}
++#endif
++
++extern int zeromount_debug_level;
++
++#define ZM_LOG(level, fmt, ...) \
++	do { \
++		if (zeromount_debug_level >= (level) && printk_ratelimit()) \
++			pr_info("ZeroMount: " fmt, ##__VA_ARGS__); \
++	} while (0)
++
++#define ZM_TRACE(fmt, ...) ZM_LOG(3, fmt, ##__VA_ARGS__)
++#define ZM_DBG(fmt, ...)  ZM_LOG(2, fmt, ##__VA_ARGS__)
++#define ZM_INFO(fmt, ...) ZM_LOG(1, fmt, ##__VA_ARGS__)
++#define ZM_ERR(fmt, ...)  pr_err("ZeroMount: " fmt, ##__VA_ARGS__)
++
++#define ZEROMOUNT_MAGIC_CODE	0x5A
++#define ZEROMOUNT_VERSION	1
++#define ZEROMOUNT_HASH_BITS	10
++#define ZM_FLAG_ACTIVE		(1 << 0)
++#define ZM_FLAG_IS_DIR		(1 << 7)
++#define ZEROMOUNT_MAGIC_POS	0x7000000000000000ULL
++
++#define ZEROMOUNT_IOC_MAGIC	ZEROMOUNT_MAGIC_CODE
++#define ZEROMOUNT_IOC_ADD_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 1, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_DEL_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 2, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_CLEAR_ALL	_IO(ZEROMOUNT_IOC_MAGIC, 3)
++#define ZEROMOUNT_IOC_GET_VERSION _IOR(ZEROMOUNT_IOC_MAGIC, 4, int)
++#define ZEROMOUNT_IOC_ADD_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 5, unsigned int)
++#define ZEROMOUNT_IOC_DEL_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 6, unsigned int)
++#define ZEROMOUNT_IOC_GET_LIST	_IOR(ZEROMOUNT_IOC_MAGIC, 7, int)
++#define ZEROMOUNT_IOC_ENABLE	_IO(ZEROMOUNT_IOC_MAGIC, 8)
++#define ZEROMOUNT_IOC_DISABLE	_IO(ZEROMOUNT_IOC_MAGIC, 9)
++#define ZEROMOUNT_IOC_REFRESH	_IO(ZEROMOUNT_IOC_MAGIC, 10)
++#define ZEROMOUNT_IOC_GET_STATUS _IOR(ZEROMOUNT_IOC_MAGIC, 11, int)
++#define MAX_LIST_BUFFER_SIZE	(64 * 1024)
++
++struct zeromount_ioctl_data {
++	char __user *virtual_path;
++	char __user *real_path;
++	unsigned int flags;
++};
++
++struct zeromount_rule {
++	struct hlist_node node;
++	struct hlist_node ino_node;
++	struct list_head list;
++	size_t vp_len;
++	char *virtual_path;
++	char *real_path;
++	unsigned long real_ino;
++	dev_t real_dev;
++	unsigned long v_ino;
++	dev_t v_dev;
++	bool is_new;
++	u32 flags;
++	struct rcu_head rcu;
++};
++
++struct zeromount_dir_node {
++	struct hlist_node node;
++	char *dir_path;
++	struct list_head children_names;
++	struct rcu_head rcu;
++};
++
++struct zeromount_child_name {
++	struct list_head list;
++	char *name;
++	unsigned char d_type;
++	struct rcu_head rcu;
++};
++
++struct zeromount_uid_node {
++	uid_t uid;
++	struct hlist_node node;
++	struct rcu_head rcu;
++};
++
++extern DECLARE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++extern struct list_head zeromount_rules_list;
++extern spinlock_t zeromount_lock;
++
++#ifdef CONFIG_ZEROMOUNT
++extern atomic_t zeromount_enabled;
++
++bool zeromount_should_skip(void);
++char *zeromount_resolve_path(const char *pathname);
++char *zeromount_build_absolute_path(int dfd, const char *name);
++struct filename *zeromount_getname_hook(struct filename *name);
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat);
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos);
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos);
++char *zeromount_get_virtual_path_for_inode(struct inode *inode);
++char *zeromount_get_static_vpath(struct inode *inode);
++void zeromount_spoof_mmap_metadata(struct inode *inode, dev_t *dev,
++				   unsigned long *ino);
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask);
++bool zeromount_is_injected_file(struct inode *inode);
++bool zeromount_is_uid_blocked(uid_t uid);
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf);
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size);
++#else
++static inline bool zeromount_should_skip(void) { return true; }
++static inline char *zeromount_resolve_path(const char *p) { return NULL; }
++static inline char *zeromount_build_absolute_path(int dfd, const char *name) { return NULL; }
++static inline struct filename *zeromount_getname_hook(struct filename *name) { return name; }
++static inline void zeromount_inject_dents_common(struct file *f, void __user **d,
++						 int *c, loff_t *p, int compat) {}
++static inline void zeromount_inject_dents64(struct file *f, void __user **d,
++					    int *c, loff_t *p) {}
++static inline void zeromount_inject_dents(struct file *f, void __user **d,
++					  int *c, loff_t *p) {}
++static inline char *zeromount_get_virtual_path_for_inode(struct inode *inode) { return NULL; }
++static inline char *zeromount_get_static_vpath(struct inode *inode) { return NULL; }
++static inline void zeromount_spoof_mmap_metadata(struct inode *inode,
++						 dev_t *dev,
++						 unsigned long *ino) {}
++static inline bool zeromount_is_traversal_allowed(struct inode *inode, int mask) { return false; }
++static inline bool zeromount_is_injected_file(struct inode *inode) { return false; }
++static inline bool zeromount_is_uid_blocked(uid_t uid) { return false; }
++static inline int zeromount_spoof_statfs(const char __user *p, struct kstatfs *b) { return 0; }
++static inline ssize_t zeromount_spoof_xattr(struct dentry *d, const char *n,
++					    void *v, size_t s) { return -EOPNOTSUPP; }
++#endif
++
++#endif /* _LINUX_ZEROMOUNT_H */

--- a/patches/zeromount/60_zeromount-android16-6.12.patch
+++ b/patches/zeromount/60_zeromount-android16-6.12.patch
@@ -1,0 +1,2206 @@
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/Kconfig work/fs/Kconfig
+--- work-50-base/fs/Kconfig	2026-03-01 05:17:51.396511222 +0100
++++ work/fs/Kconfig	2026-03-01 06:09:40.950669509 +0100
+@@ -432,4 +432,11 @@
+ config IO_WQ
+ 	bool
+ 
++config ZEROMOUNT
++	bool "ZeroMount Path Redirection Subsystem"
++	default y
++	help
++	  ZeroMount allows path redirection and virtual file injection
++	  without mounting filesystems. Useful for systemless modifications.
++
+ endmenu
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/Makefile work/fs/Makefile
+--- work-50-base/fs/Makefile	2026-03-01 05:27:32.054784361 +0100
++++ work/fs/Makefile	2026-03-01 06:13:04.508054204 +0100
+@@ -23,6 +23,7 @@
+ 		kernel_read_file.o mnt_idmapping.o remap_range.o pidfs.o
+ 
+ obj-$(CONFIG_KSU_SUSFS) += susfs.o
++obj-$(CONFIG_ZEROMOUNT)		+= zeromount.o
+ 
+ obj-$(CONFIG_BUFFER_HEAD)	+= buffer.o mpage.o
+ obj-$(CONFIG_PROC_FS)		+= proc_namespace.o
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/d_path.c work/fs/d_path.c
+--- work-50-base/fs/d_path.c	2026-03-01 05:17:52.488486670 +0100
++++ work/fs/d_path.c	2026-03-01 06:09:40.951075001 +0100
+@@ -8,6 +8,10 @@
+ #include <linux/prefetch.h>
+ #include "mount.h"
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ 
+ struct prepend_buffer {
+ 	char *buf;
+@@ -267,6 +271,20 @@
+ 	DECLARE_BUFFER(b, buf, buflen);
+ 	struct path root;
+
++#ifdef CONFIG_ZEROMOUNT
++	if (path->dentry && d_backing_inode(path->dentry)) {
++		char *v_path = zeromount_get_static_vpath(d_backing_inode(path->dentry));
++
++		if (v_path) {
++			prepend_char(&b, 0);
++			prepend(&b, v_path, strlen(v_path));
++			kfree(v_path);
++			return extract_string(&b);
++		}
++	}
++#endif
++
++
+ 	/*
+ 	 * We have various synthetic filesystems that never get mounted.  On
+ 	 * these filesystems dentries are never used for lookup purposes, and
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/namei.c work/fs/namei.c
+--- work-50-base/fs/namei.c	2026-03-01 05:42:04.393035305 +0100
++++ work/fs/namei.c	2026-03-01 06:09:41.091390946 +0100
+@@ -48,6 +48,10 @@
+ #include "mount.h"
+
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ extern bool susfs_is_inode_sus_path(struct mnt_idmap* idmap, struct inode *inode);
+ extern const struct qstr susfs_fake_qstr_name;
+ #endif
+@@ -219,6 +223,13 @@
+ 	result->uptr = filename;
+ 	result->aname = NULL;
+ 	audit_getname(result);
++
++#ifdef CONFIG_ZEROMOUNT
++	if (!IS_ERR(result)) {
++		result = zeromount_getname_hook(result);
++	}
++#endif
++
+ 	return result;
+ }
+ 
+@@ -419,6 +430,18 @@
+ {
+ 	int ret;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	/*
+ 	 * Do the basic permission checks.
+ 	 */
+@@ -523,6 +546,18 @@
+ {
+ 	int retval;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (zeromount_is_injected_file(inode)) {
++		if (mask & MAY_WRITE)
++			return -EACCES;
++		return 0;
++	}
++
++	if (S_ISDIR(inode->i_mode) && zeromount_is_traversal_allowed(inode, mask)) {
++		return 0;
++	}
++#endif
++
+ 	retval = sb_permission(inode->i_sb, inode, mask);
+ 	if (retval)
+ 		return retval;
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/proc/base.c work/fs/proc/base.c
+--- work-50-base/fs/proc/base.c	2026-03-01 05:27:32.058615314 +0100
++++ work/fs/proc/base.c	2026-03-01 06:09:41.356479099 +0100
+@@ -107,6 +107,9 @@
+ #include <trace/events/oom.h>
+ #include <trace/hooks/sched.h>
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include "fd.h"
+ 
+ #include "../../lib/kstrtox.h"
+@@ -1862,6 +1865,26 @@
+ 	if (!tmp)
+ 		return -ENOMEM;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (!zeromount_should_skip() && path->dentry) {
++		struct inode *inode = d_backing_inode(path->dentry);
++		if (inode) {
++			char *vpath = zeromount_get_static_vpath(inode);
++			if (vpath) {
++				int vlen = strlen(vpath);
++				if (vlen > buflen)
++					vlen = buflen;
++				if (copy_to_user(buffer, vpath, vlen) == 0) {
++					kfree(vpath);
++					kfree(tmp);
++					return vlen;
++				}
++				kfree(vpath);
++			}
++		}
++	}
++#endif
++
+ 	pathname = d_path(path, tmp, PATH_MAX);
+ 	len = PTR_ERR(pathname);
+ 
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/proc/task_mmu.c work/fs/proc/task_mmu.c
+--- work-50-base/fs/proc/task_mmu.c	2026-03-01 05:27:32.059714569 +0100
++++ work/fs/proc/task_mmu.c	2026-03-01 06:09:41.357867226 +0100
+@@ -20,6 +20,9 @@
+ #include <linux/mmu_notifier.h>
+ #include <linux/page_idle.h>
+ #include <linux/page_size_compat.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <linux/shmem_fs.h>
+ #include <linux/uaccess.h>
+ #include <linux/pkeys.h>
+@@ -504,6 +507,9 @@
+ #endif
+ 		dev = inode->i_sb->s_dev;
+ 		ino = inode->i_ino;
++#ifdef CONFIG_ZEROMOUNT
++		zeromount_spoof_mmap_metadata(inode, &dev, &ino);
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ bypass_orig_flow:
+ #endif
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/readdir.c work/fs/readdir.c
+--- work-50-base/fs/readdir.c	2026-03-01 05:27:32.061062044 +0100
++++ work/fs/readdir.c	2026-03-01 06:12:59.504163195 +0100
+@@ -21,6 +21,9 @@
+ #include <linux/unistd.h>
+ #include <linux/compat.h>
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ #include <linux/susfs_def.h>
+@@ -364,11 +367,21 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!fd_file(f))
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (fd_file(f)->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = fd_file(f)->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(fd_file(f)->f_path.mnt);
+@@ -377,6 +390,16 @@
+ 	error = iterate_dir(fd_file(f), &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(fd_file(f), (void __user **)&dirent, &count, &fd_file(f)->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -386,6 +409,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -472,11 +498,21 @@
+ 		.current_dir = dirent
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!fd_file(f))
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (fd_file(f)->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = fd_file(f)->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(fd_file(f)->f_path.mnt);
+@@ -485,6 +521,16 @@
+ 	error = iterate_dir(fd_file(f), &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents64(fd_file(f), (void __user **)&dirent, &count, &fd_file(f)->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct linux_dirent64 __user * lastdirent;
+ 		typeof(lastdirent->d_off) d_off = buf.ctx.pos;
+@@ -495,6 +541,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+@@ -688,11 +737,21 @@
+ 		.count = count
+ 	};
+ 	int error;
++#ifdef CONFIG_ZEROMOUNT
++	int initial_count = count;
++#endif
+ 
+ 	f = fdget_pos(fd);
+ 	if (!fd_file(f))
+ 		return -EBADF;
+ 
++#ifdef CONFIG_ZEROMOUNT
++	if (fd_file(f)->f_pos >= ZEROMOUNT_MAGIC_POS) {
++		error = 0;
++		goto skip_real_iterate;
++	}
++#endif
++
+ #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+ 	buf.sb = fd_file(f)->f_inode->i_sb;
+ 	buf.idmap = mnt_idmap(fd_file(f)->f_path.mnt);
+@@ -701,6 +760,16 @@
+ 	error = iterate_dir(fd_file(f), &buf.ctx);
+ 	if (error >= 0)
+ 		error = buf.error;
++
++#ifdef CONFIG_ZEROMOUNT
++skip_real_iterate:
++	if (error >= 0 && !signal_pending(current)) {
++		zeromount_inject_dents(fd_file(f), (void __user **)&dirent, &count, &fd_file(f)->f_pos);
++		if (count != initial_count)
++			error = initial_count - count;
++		goto zm_out;
++	}
++#endif
+ 	if (buf.prev_reclen) {
+ 		struct compat_linux_dirent __user * lastdirent;
+ 		lastdirent = (void __user *)buf.current_dir - buf.prev_reclen;
+@@ -710,6 +779,9 @@
+ 		else
+ 			error = count - buf.count;
+ 	}
++#ifdef CONFIG_ZEROMOUNT
++zm_out:
++#endif
+ 	fdput_pos(f);
+ 	return error;
+ }
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/stat.c work/fs/stat.c
+--- work-50-base/fs/stat.c	2026-03-01 05:43:37.967072690 +0100
++++ work/fs/stat.c	2026-03-01 06:09:41.093152614 +0100
+@@ -25,6 +25,9 @@
+ #include <linux/version.h>
+ #endif
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ #include <asm/unistd.h>
+ 
+ #include "internal.h"
+@@ -251,2 +254,36 @@
+ 
++#ifdef CONFIG_ZEROMOUNT
++static inline int zeromount_stat_hook(int dfd, struct filename *filename,
++                                      struct kstat *stat, unsigned int request_mask,
++                                      int flags) {
++    const char *kname;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
++    if (!filename || IS_ERR(filename)) return -ENOENT;
++    kname = filename->name;
++    if (kname && kname[0] != '/') {
++        char *abs_path = zeromount_build_absolute_path(dfd, kname);
++        if (abs_path) {
++            char *resolved = zeromount_resolve_path(abs_path);
++            if (resolved) {
++                struct path zm_path;
++                int zm_ret;
++                zm_enter();
++                zm_ret = kern_path(resolved, (flags & AT_SYMLINK_NOFOLLOW) ? 0 : LOOKUP_FOLLOW, &zm_path);
++                zm_exit();
++                kfree(resolved);
++                kfree(abs_path);
++                if (zm_ret == 0) {
++                    zm_ret = vfs_getattr(&zm_path, stat, request_mask,
++                                         (flags & AT_SYMLINK_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
++                    path_put(&zm_path);
++                    return zm_ret;
++                }
++            } else {
++                kfree(abs_path);
++            }
++        }
++    }
++    return -ENOENT;
++}
++#endif
+ int vfs_fstat(int fd, struct kstat *stat)
+@@ -363,6 +400,16 @@
+ #endif
+ 
+ 
++#ifdef CONFIG_ZEROMOUNT
++	/* Try ZeroMount hook for relative paths */
++	if (filename) {
++		int zm_ret = zeromount_stat_hook(dfd, filename, stat, request_mask, flags);
++		if (zm_ret != -ENOENT)
++			return zm_ret;
++	}
++#endif
++
++
+ #ifdef CONFIG_KSU_SUSFS_UNICODE_FILTER
+ 	if (!IS_ERR(filename) && susfs_check_unicode_bypass(filename->uptr)) {
+ 		return -ENOENT;
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/statfs.c work/fs/statfs.c
+--- work-50-base/fs/statfs.c	2026-03-01 05:27:32.061757439 +0100
++++ work/fs/statfs.c	2026-03-01 06:09:41.093424141 +0100
+@@ -14,6 +14,9 @@
+ #include "mount.h"
+ #endif
+ #include "internal.h"
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ static int flags_by_mnt(int mnt_flags)
+ {
+@@ -118,7 +121,14 @@
+ retry:
+ 	error = user_path_at(AT_FDCWD, pathname, lookup_flags, &path);
+ 	if (!error) {
++#ifdef CONFIG_ZEROMOUNT
++		int spoofed;
++#endif
+ 		error = vfs_statfs(&path, st);
++#ifdef CONFIG_ZEROMOUNT
++		spoofed = zeromount_spoof_statfs(pathname, st);
++		(void)spoofed;
++#endif
+ 		path_put(&path);
+ 		if (retry_estale(error, lookup_flags)) {
+ 			lookup_flags |= LOOKUP_REVAL;
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/xattr.c work/fs/xattr.c
+--- work-50-base/fs/xattr.c	2026-03-01 05:17:52.976475699 +0100
++++ work/fs/xattr.c	2026-03-01 06:09:41.194492204 +0100
+@@ -24,6 +24,9 @@
+ #include <linux/posix_acl_xattr.h>
+ 
+ #include <linux/uaccess.h>
++#ifdef CONFIG_ZEROMOUNT
++#include <linux/zeromount.h>
++#endif
+ 
+ #include "internal.h"
+ 
+@@ -427,7 +430,13 @@
+ ssize_t
+ vfs_getxattr(struct mnt_idmap *idmap, struct dentry *dentry,
+ 	     const char *name, void *value, size_t size)
+ {
++#ifdef CONFIG_ZEROMOUNT
++	ssize_t zm_ret;
++	zm_ret = zeromount_spoof_xattr(dentry, name, value, size);
++	if (zm_ret != -EOPNOTSUPP)
++		return zm_ret;
++#endif
+ 	struct inode *inode = dentry->d_inode;
+ 	int error;
+ 
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/zeromount.c work/fs/zeromount.c
+--- work-50-base/fs/zeromount.c	1970-01-01 01:00:00.000000000 +0100
++++ work/fs/zeromount.c	2026-03-01 06:15:21.445071545 +0100
+@@ -0,0 +1,1526 @@
++#include <linux/module.h>
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/fs.h>
++#include <linux/dcache.h>
++#include <linux/path.h>
++#include <linux/namei.h>
++#include <linux/sched.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++#include <linux/uaccess.h>
++#include <linux/dirent.h>
++#include <linux/miscdevice.h>
++#include <linux/cred.h>
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include <linux/zeromount.h>
++#include <linux/kobject.h>
++#include <linux/sysfs.h>
++#include <linux/statfs.h>
++#include <linux/file.h>
++#include <linux/fs_struct.h>
++#ifdef CONFIG_KSU_SUSFS
++#include <linux/susfs.h>
++#endif
++#include <linux/reboot.h>
++#include <linux/bitmap.h>
++
++int zeromount_debug_level = 0;
++
++DEFINE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++DEFINE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++LIST_HEAD(zeromount_rules_list);
++DEFINE_SPINLOCK(zeromount_lock);
++
++atomic_t zeromount_enabled = ATOMIC_INIT(0);
++static atomic_t zeromount_dirs_count = ATOMIC_INIT(0);
++static atomic_t zeromount_rule_count = ATOMIC_INIT(0);
++static DECLARE_BITMAP(zm_bloom, ZM_BLOOM_BITS);
++#define ZEROMOUNT_DISABLED() (atomic_read(&zeromount_enabled) == 0)
++
++static inline void zm_bloom_add(u32 hash)
++{
++	set_bit(hash & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom);
++	set_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static inline bool zm_bloom_test(u32 hash)
++{
++	return test_bit(hash & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 10) & ZM_BLOOM_MASK, zm_bloom) &&
++	       test_bit((hash >> 20) & ZM_BLOOM_MASK, zm_bloom);
++}
++
++static void zm_bloom_rebuild(void)
++{
++	struct zeromount_rule *rule;
++	int count = 0;
++
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		u32 h = full_name_hash(NULL, rule->virtual_path, rule->vp_len);
++		zm_bloom_add(h);
++		count++;
++	}
++	ZM_DBG("bloom: rebuilt (%d rules)\n", count);
++}
++
++struct linux_dirent {
++	unsigned long	d_ino;
++	unsigned long	d_off;
++	unsigned short	d_reclen;
++	char		d_name[];
++};
++
++static unsigned long zm_ino_adb = 0;
++static unsigned long zm_ino_modules = 0;
++
++static inline bool zeromount_is_critical_process(void)
++{
++	const char *comm = current->comm;
++
++	switch (comm[0]) {
++	case 'i': if (comm[1] == 'n' && comm[2] == 'i') return true; break;
++	case 'u': if (comm[1] == 'e' && comm[2] == 'v') return true; break;
++	case 'v': if (comm[1] == 'o' && comm[2] == 'l') return true; break;
++	}
++	if (current->flags & PF_KTHREAD)
++		return true;
++	return false;
++}
++
++bool zeromount_should_skip(void)
++{
++	if (ZEROMOUNT_DISABLED())
++		return true;
++	if (zm_is_recursive())
++		return true;
++	if (unlikely(in_interrupt() || in_nmi() || oops_in_progress))
++		return true;
++	if (!current || !current->mm)
++		return true;
++	if (current->flags & PF_EXITING)
++		return true;
++	if (zeromount_is_critical_process())
++		return true;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return true;
++#endif
++	return false;
++}
++EXPORT_SYMBOL(zeromount_should_skip);
++
++bool zeromount_is_uid_blocked(uid_t uid)
++{
++	struct zeromount_uid_node *entry;
++
++	if (ZEROMOUNT_DISABLED())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return true;
++#endif
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_uid_ht, entry, node, uid) {
++		if (entry->uid == uid) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_uid_blocked);
++
++bool zeromount_match_path(const char *input_path, const char *rule_path)
++{
++	if (!input_path || !rule_path)
++		return false;
++	if (strcmp(input_path, rule_path) == 0)
++		return true;
++	if (strncmp(input_path, "/system", 7) == 0) {
++		if (strcmp(input_path + 7, rule_path) == 0)
++			return true;
++	}
++	return false;
++}
++
++/* Zero-alloc normalize: compute adjusted base and length in-place */
++static inline void zeromount_normalize_inline(const char *path,
++					      const char **out_p,
++					      size_t *out_len)
++{
++	const char *p = path;
++	size_t len;
++
++	if (strncmp(path, "/system/", 8) == 0)
++		p = path + 7;
++
++	len = strlen(p);
++	while (len > 1 && p[len - 1] == '/')
++		len--;
++
++	*out_p = p;
++	*out_len = len;
++}
++
++/* Alloc variant for callers that need a persistent copy */
++static char *zeromount_normalize_path(const char *path)
++{
++	const char *p;
++	size_t len;
++	char *normalized;
++
++	if (!path)
++		return NULL;
++
++	zeromount_normalize_inline(path, &p, &len);
++
++	normalized = kmalloc(len + 1, GFP_KERNEL);
++	if (!normalized)
++		return NULL;
++
++	memcpy(normalized, p, len);
++	normalized[len] = '\0';
++	return normalized;
++}
++
++static void zeromount_free_rule_rcu(struct rcu_head *head)
++{
++	struct zeromount_rule *rule = container_of(head, struct zeromount_rule, rcu);
++
++	kfree(rule->virtual_path);
++	kfree(rule->real_path);
++	kfree(rule);
++}
++
++static void zeromount_free_child_rcu(struct rcu_head *head)
++{
++	struct zeromount_child_name *child =
++		container_of(head, struct zeromount_child_name, rcu);
++
++	kfree(child->name);
++	kfree(child);
++}
++
++static void zeromount_free_dir_node_rcu(struct rcu_head *head)
++{
++	struct zeromount_dir_node *node =
++		container_of(head, struct zeromount_dir_node, rcu);
++
++	kfree(node->dir_path);
++	kfree(node);
++}
++
++static void zeromount_flush_parent(const char *full_path)
++{
++	char *path_copy, *last_slash, *parent_str, *child_name;
++	struct path parent;
++
++	path_copy = kstrdup(full_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_str = path_copy;
++	child_name = last_slash + 1;
++
++	if (*child_name == '\0') {
++		kfree(path_copy);
++		return;
++	}
++
++	if (kern_path(parent_str, LOOKUP_FOLLOW, &parent) == 0) {
++		struct dentry *child;
++
++		inode_lock(parent.dentry->d_inode);
++		child = lookup_one_len(child_name, parent.dentry,
++				       strlen(child_name));
++		if (!IS_ERR(child)) {
++			d_invalidate(child);
++			d_drop(child);
++			dput(child);
++		}
++		inode_unlock(parent.dentry->d_inode);
++		path_put(&parent);
++	}
++
++	kfree(path_copy);
++}
++
++static void zeromount_flush_dcache(const char *path_name)
++{
++	struct path path;
++	int err;
++
++	zm_enter();
++	err = kern_path(path_name, LOOKUP_FOLLOW, &path);
++	if (!err) {
++		d_invalidate(path.dentry);
++		d_drop(path.dentry);
++		path_put(&path);
++	} else if (err == -ENOENT) {
++		zeromount_flush_parent(path_name);
++	}
++	zm_exit();
++}
++
++static void zeromount_force_refresh_all(void)
++{
++	struct zeromount_rule *rule;
++	char **paths = NULL;
++	int count = 0, i = 0;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list)
++		count++;
++	spin_unlock(&zeromount_lock);
++
++	if (count == 0)
++		return;
++
++	paths = kvmalloc_array(count, sizeof(char *), GFP_KERNEL);
++	if (!paths)
++		return;
++
++	spin_lock(&zeromount_lock);
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		if (i >= count)
++			break;
++		paths[i] = kstrdup(rule->virtual_path, GFP_ATOMIC);
++		if (!paths[i])
++			break;
++		i++;
++	}
++	spin_unlock(&zeromount_lock);
++
++	for (count = i, i = 0; i < count; i++) {
++		zeromount_flush_dcache(paths[i]);
++		kfree(paths[i]);
++	}
++	kvfree(paths);
++}
++
++static unsigned long zeromount_generate_ino(const char *dir, const char *name)
++{
++	u32 h1 = full_name_hash(NULL, dir, strlen(dir));
++	u32 h2 = full_name_hash(NULL, name, strlen(name));
++
++	return (unsigned long)(h1 ^ h2);
++}
++
++char *zeromount_get_virtual_path_for_inode(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *found_path = NULL;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return NULL;
++	if (zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			if (READ_ONCE(rule->is_new))
++				found_path = kstrdup(rule->virtual_path,
++						     GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return found_path;
++}
++EXPORT_SYMBOL(zeromount_get_virtual_path_for_inode);
++
++/* Returns kstrdup'd copy; caller must kfree. GFP_ATOMIC safe from any context. */
++char *zeromount_get_static_vpath(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++	char *copy = NULL;
++
++	if (unlikely(!inode || !inode->i_sb))
++		return NULL;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			copy = kstrdup(rule->virtual_path, GFP_ATOMIC);
++			break;
++		}
++	}
++	rcu_read_unlock();
++	return copy;
++}
++EXPORT_SYMBOL(zeromount_get_static_vpath);
++
++/* Spoof dev/ino in /proc/PID/maps for redirected mmap'd files */
++void zeromount_spoof_mmap_metadata(const struct inode *inode, dev_t *dev,
++				   unsigned long *ino)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (unlikely(!inode || !dev || !ino))
++		return;
++	if (zeromount_should_skip())
++		return;
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev &&
++		    (rule->flags & ZM_FLAG_ACTIVE)) {
++			*dev = READ_ONCE(rule->v_dev);
++			*ino = READ_ONCE(rule->v_ino);
++			break;
++		}
++	}
++	rcu_read_unlock();
++}
++EXPORT_SYMBOL(zeromount_spoof_mmap_metadata);
++
++static unsigned long zeromount_get_inode_by_path(const char *path_str)
++{
++	struct path path;
++	struct inode *inode;
++	unsigned long ino = 0;
++
++	if (kern_path(path_str, LOOKUP_FOLLOW, &path) == 0) {
++		inode = d_backing_inode(path.dentry);
++		if (inode)
++			ino = inode->i_ino;
++		path_put(&path);
++	}
++	return ino;
++}
++
++static void zeromount_refresh_critical_inodes(void)
++{
++	if (READ_ONCE(zm_ino_adb) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_adb, ino);
++	}
++	if (READ_ONCE(zm_ino_modules) == 0) {
++		unsigned long ino = zeromount_get_inode_by_path("/data/adb/modules");
++		if (ino != 0)
++			WRITE_ONCE(zm_ino_modules, ino);
++	}
++}
++
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask)
++{
++	if (!inode || zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return false;
++#endif
++	if (!(mask & MAY_EXEC))
++		return false;
++
++	if ((READ_ONCE(zm_ino_adb) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_adb)) ||
++	    (READ_ONCE(zm_ino_modules) != 0 &&
++	     inode->i_ino == READ_ONCE(zm_ino_modules)))
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_traversal_allowed);
++
++bool zeromount_is_injected_file(struct inode *inode)
++{
++	struct zeromount_rule *rule;
++	unsigned long key;
++
++	if (!inode || !inode->i_sb || zeromount_should_skip())
++		return false;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return false;
++#endif
++
++	key = inode->i_ino ^ inode->i_sb->s_dev;
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return false;
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_ino_ht, rule, ino_node, key) {
++		if (rule->real_ino == inode->i_ino &&
++		    rule->real_dev == inode->i_sb->s_dev) {
++			rcu_read_unlock();
++			return true;
++		}
++	}
++	rcu_read_unlock();
++	return false;
++}
++EXPORT_SYMBOL(zeromount_is_injected_file);
++
++char *zeromount_resolve_path(const char *pathname)
++{
++	struct zeromount_rule *rule;
++	char *target = NULL;
++	const char *normalized;
++	size_t norm_len;
++	u32 hash;
++
++	if (zeromount_is_critical_process())
++		return NULL;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return NULL;
++#endif
++	if (ZEROMOUNT_DISABLED() ||
++	    zeromount_is_uid_blocked(current_uid().val) || !pathname)
++		return NULL;
++
++	zeromount_normalize_inline(pathname, &normalized, &norm_len);
++	hash = full_name_hash(NULL, normalized, norm_len);
++
++	if (atomic_read(&zeromount_rule_count) == 0)
++		return NULL;
++
++	if (!zm_bloom_test(hash)) {
++		ZM_TRACE("bloom: reject hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++		return NULL;
++	}
++	ZM_DBG("bloom: pass hash=0x%08x path=%.*s\n", hash, (int)norm_len, normalized);
++
++	rcu_read_lock();
++	hash_for_each_possible_rcu(zeromount_rules_ht, rule, node, hash) {
++		if (rule->vp_len == norm_len &&
++		    memcmp(normalized, rule->virtual_path, norm_len) == 0) {
++			if (rule->flags & ZM_FLAG_ACTIVE) {
++				target = kstrdup(rule->real_path, GFP_ATOMIC);
++				break;
++			}
++		}
++	}
++	rcu_read_unlock();
++	return target;
++}
++EXPORT_SYMBOL(zeromount_resolve_path);
++
++static char *zeromount_resolve_dirfd_path(int dfd, char *buf, int buflen)
++{
++	struct fd f;
++	char *path;
++
++	if (dfd == AT_FDCWD) {
++		struct path pwd;
++
++		if (unlikely(!current->fs))
++			return ERR_PTR(-ENOENT);
++		get_fs_pwd(current->fs, &pwd);
++		path = d_path(&pwd, buf, buflen);
++		path_put(&pwd);
++		return path;
++	}
++
++	f = fdget(dfd);
++	if (!fd_file(f))
++		return ERR_PTR(-EBADF);
++
++	path = d_path(&fd_file(f)->f_path, buf, buflen);
++	fdput(f);
++	return path;
++}
++
++char *zeromount_build_absolute_path(int dfd, const char *name)
++{
++	char *page_buf, *dir_path, *abs_path;
++	size_t dir_len, name_len;
++
++	if (!name || name[0] == '/' || *name == '\0')
++		return NULL;
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return NULL;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return NULL;
++
++	dir_path = zeromount_resolve_dirfd_path(dfd, page_buf, PATH_MAX);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	dir_len = strlen(dir_path);
++	name_len = strlen(name);
++
++	if (dir_len > PATH_MAX || name_len > NAME_MAX ||
++	    dir_len + name_len + 2 > PATH_MAX) {
++		__putname(page_buf);
++		return NULL;
++	}
++
++	abs_path = kmalloc(dir_len + 1 + name_len + 1, GFP_KERNEL);
++	if (abs_path) {
++		memcpy(abs_path, dir_path, dir_len);
++		abs_path[dir_len] = '/';
++		memcpy(abs_path + dir_len + 1, name, name_len + 1);
++	}
++
++	__putname(page_buf);
++	return abs_path;
++}
++EXPORT_SYMBOL(zeromount_build_absolute_path);
++
++struct filename *zeromount_getname_hook(struct filename *name)
++{
++	char *target_path;
++	struct filename *new_name;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val) ||
++	    !name || name->name[0] != '/')
++		return name;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return name;
++#endif
++
++	zm_enter();
++
++	target_path = zeromount_resolve_path(name->name);
++	if (!target_path) {
++		zm_exit();
++		return name;
++	}
++
++	new_name = getname_kernel(target_path);
++	kfree(target_path);
++
++	if (IS_ERR(new_name)) {
++		zm_exit();
++		return name;
++	}
++
++	putname(name);
++	zm_exit();
++	return new_name;
++}
++
++/* Merged readdir injection: compat=0 for dirent64, compat=1 for dirent */
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat)
++{
++	char *page_buf, *dir_path;
++	unsigned long v_index;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted()) return;
++#endif
++
++	if (atomic_read(&zeromount_dirs_count) == 0 &&
++	    *pos < ZEROMOUNT_MAGIC_POS)
++		return;
++
++	page_buf = __getname();
++	if (!page_buf)
++		return;
++
++	dir_path = d_path(&file->f_path, page_buf, PAGE_SIZE);
++	if (IS_ERR(dir_path)) {
++		__putname(page_buf);
++		return;
++	}
++
++	/* Skip if this directory is itself redirected */
++	{
++		const char *norm_p;
++		size_t norm_len;
++		u32 dir_hash;
++		bool is_redirected = false;
++
++		zeromount_normalize_inline(dir_path, &norm_p, &norm_len);
++		dir_hash = full_name_hash(NULL, norm_p, norm_len);
++
++		rcu_read_lock();
++		{
++			struct zeromount_rule *rule;
++
++			hash_for_each_possible_rcu(zeromount_rules_ht, rule,
++						   node, dir_hash) {
++				if (rule->vp_len == norm_len &&
++				    memcmp(norm_p, rule->virtual_path,
++					   norm_len) == 0 &&
++				    (rule->flags & ZM_FLAG_ACTIVE)) {
++					is_redirected = true;
++					break;
++				}
++			}
++		}
++		rcu_read_unlock();
++
++		if (is_redirected) {
++			__putname(page_buf);
++			return;
++		}
++	}
++
++	if (*pos >= ZEROMOUNT_MAGIC_POS) {
++		v_index = *pos - ZEROMOUNT_MAGIC_POS;
++	} else {
++		v_index = 0;
++	}
++
++	{
++		struct zeromount_dir_node *zm_dir;
++		struct zeromount_child_name *zm_child;
++		const char *normalized;
++		size_t normalized_len;
++		u32 zm_hash;
++		unsigned long cur_idx = 0;
++
++		zeromount_normalize_inline(dir_path, &normalized,
++					  &normalized_len);
++		zm_hash = full_name_hash(NULL, normalized, normalized_len);
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_dirs_ht, zm_dir,
++					   node, zm_hash) {
++			if (strlen(zm_dir->dir_path) != normalized_len ||
++			    memcmp(normalized, zm_dir->dir_path,
++				   normalized_len) != 0)
++				continue;
++
++			if (*pos < ZEROMOUNT_MAGIC_POS)
++				*pos = ZEROMOUNT_MAGIC_POS;
++
++			list_for_each_entry_rcu(zm_child,
++						&zm_dir->children_names,
++						list) {
++				char name_local[256];
++				unsigned char type_local;
++				int name_len, reclen;
++				unsigned long fake_ino;
++
++				if (cur_idx++ < v_index)
++					continue;
++
++				strscpy(name_local, zm_child->name,
++					sizeof(name_local));
++				type_local = zm_child->d_type;
++				name_len = strlen(name_local);
++
++				if (compat) {
++					struct linux_dirent __user *de;
++
++					reclen = ALIGN(offsetof(struct linux_dirent, d_name) + name_len + 2, 4);
++					if (*count < reclen)
++						break;
++					de = (struct linux_dirent __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de->d_off) ||
++					    put_user(reclen, &de->d_reclen) ||
++					    copy_to_user(de->d_name, name_local, name_len) ||
++					    put_user(0, de->d_name + name_len) ||
++					    put_user(type_local, ((char __user *)de) + reclen - 1))
++						break;
++				} else {
++					struct linux_dirent64 __user *de64;
++
++					reclen = ALIGN(offsetof(struct linux_dirent64, d_name) + name_len + 1, sizeof(u64));
++					if (*count < reclen)
++						break;
++					de64 = (struct linux_dirent64 __user *)*dirent;
++					fake_ino = zeromount_generate_ino(dir_path, name_local);
++					if (put_user(fake_ino, &de64->d_ino) ||
++					    put_user(ZEROMOUNT_MAGIC_POS + v_index + 1, &de64->d_off) ||
++					    put_user(reclen, &de64->d_reclen) ||
++					    put_user(type_local, &de64->d_type) ||
++					    copy_to_user(de64->d_name, name_local, name_len) ||
++					    put_user(0, de64->d_name + name_len))
++						break;
++				}
++
++				*dirent = (void __user *)((char __user *)*dirent + reclen);
++				*count -= reclen;
++				v_index++;
++				*pos = ZEROMOUNT_MAGIC_POS + v_index;
++			}
++			break;
++		}
++		rcu_read_unlock();
++	}
++
++	__putname(page_buf);
++}
++
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 0);
++}
++
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos)
++{
++	zeromount_inject_dents_common(file, dirent, count, pos, 1);
++}
++
++#define EROFS_SUPER_MAGIC 0xE0F5E1E2
++#define EXT4_SUPER_MAGIC  0xEF53
++#define F2FS_SUPER_MAGIC  0xF2F52010
++
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf)
++{
++	char *kpath;
++	char *resolved;
++	int ret = 0;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return 0;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return 0;
++#endif
++
++	kpath = strndup_user(pathname, PATH_MAX);
++	if (IS_ERR(kpath))
++		return 0;
++
++	resolved = zeromount_resolve_path(kpath);
++	if (!resolved) {
++		kfree(kpath);
++		return 0;
++	}
++
++	if (strncmp(kpath, "/system", 7) == 0 ||
++	    strncmp(kpath, "/vendor", 7) == 0 ||
++	    strncmp(kpath, "/product", 8) == 0 ||
++	    strncmp(kpath, "/odm", 4) == 0) {
++		buf->f_type = EROFS_SUPER_MAGIC;
++		ret = 1;
++	}
++
++	kfree(kpath);
++	kfree(resolved);
++	return ret;
++}
++EXPORT_SYMBOL(zeromount_spoof_statfs);
++
++static const char *zeromount_get_selinux_context(const char *vpath)
++{
++	if (!vpath)
++		return NULL;
++
++	if (strncmp(vpath, "/lib64", 6) == 0 ||
++	    strncmp(vpath, "/lib", 4) == 0)
++		return "u:object_r:system_lib_file:s0";
++
++	if (strncmp(vpath, "/bin", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/fonts", 6) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/framework", 10) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/etc", 4) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (strncmp(vpath, "/vendor", 7) == 0)
++		return "u:object_r:vendor_file:s0";
++
++	if (strncmp(vpath, "/product", 8) == 0)
++		return "u:object_r:system_file:s0";
++
++	if (vpath[0] == '/')
++		return "u:object_r:system_file:s0";
++
++	return NULL;
++}
++
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size)
++{
++	struct inode *inode;
++	char *vpath;
++	const char *context;
++	size_t ctx_len;
++
++	if (zeromount_should_skip() ||
++	    zeromount_is_uid_blocked(current_uid().val))
++		return -EOPNOTSUPP;
++#ifdef CONFIG_KSU_SUSFS
++	if (susfs_is_current_proc_umounted())
++		return -EOPNOTSUPP;
++#endif
++
++	if (!dentry || !name)
++		return -EOPNOTSUPP;
++
++	if (strcmp(name, "security.selinux") != 0)
++		return -EOPNOTSUPP;
++
++	inode = d_backing_inode(dentry);
++	if (!inode)
++		return -EOPNOTSUPP;
++
++	vpath = zeromount_get_virtual_path_for_inode(inode);
++	if (!vpath)
++		return -EOPNOTSUPP;
++
++	context = zeromount_get_selinux_context(vpath);
++	kfree(vpath);
++
++	if (!context)
++		return -EOPNOTSUPP;
++
++	ctx_len = strlen(context) + 1;
++
++	if (size == 0)
++		return ctx_len;
++	if (size < ctx_len)
++		return -ERANGE;
++
++	memcpy(value, context, ctx_len);
++	return ctx_len;
++}
++EXPORT_SYMBOL(zeromount_spoof_xattr);
++
++static void zeromount_auto_inject_parent(const char *v_path,
++					 unsigned char type, int depth)
++{
++	char *parent_path, *name, *path_copy, *last_slash;
++	struct zeromount_dir_node *dir_node = NULL, *curr;
++	struct zeromount_child_name *child;
++	u32 hash;
++	bool child_exists = false;
++
++	if (depth > 20)
++		return;
++
++	/* Existing path on real fs means all ancestors exist too */
++	{
++		struct path check;
++		if (kern_path(v_path, LOOKUP_FOLLOW, &check) == 0) {
++			path_put(&check);
++			return;
++		}
++	}
++
++	path_copy = kstrdup(v_path, GFP_KERNEL);
++	if (!path_copy)
++		return;
++
++	last_slash = strrchr(path_copy, '/');
++	if (!last_slash || last_slash == path_copy) {
++		kfree(path_copy);
++		return;
++	}
++
++	*last_slash = '\0';
++	parent_path = path_copy;
++	name = last_slash + 1;
++
++	/* Skip if parent dir is VFS-redirected */
++	{
++		u32 parent_hash = full_name_hash(NULL, parent_path,
++						 strlen(parent_path));
++		struct zeromount_rule *parent_rule;
++		bool parent_redirected = false;
++
++		rcu_read_lock();
++		hash_for_each_possible_rcu(zeromount_rules_ht, parent_rule,
++					   node, parent_hash) {
++			if (strcmp(parent_rule->virtual_path, parent_path) == 0 &&
++			    READ_ONCE(parent_rule->is_new)) {
++				parent_redirected = true;
++				break;
++			}
++		}
++		rcu_read_unlock();
++
++		if (parent_redirected) {
++			kfree(path_copy);
++			return;
++		}
++	}
++
++	zeromount_auto_inject_parent(parent_path, DT_DIR, depth + 1);
++
++	hash = full_name_hash(NULL, parent_path, strlen(parent_path));
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_possible(zeromount_dirs_ht, curr, node, hash) {
++		if (strcmp(curr->dir_path, parent_path) == 0) {
++			dir_node = curr;
++			break;
++		}
++	}
++
++	if (!dir_node) {
++		dir_node = kzalloc(sizeof(*dir_node), GFP_ATOMIC);
++		if (!dir_node)
++			goto unlock_out;
++
++		dir_node->dir_path = kstrdup(parent_path, GFP_ATOMIC);
++		INIT_LIST_HEAD(&dir_node->children_names);
++		hash_add_rcu(zeromount_dirs_ht, &dir_node->node, hash);
++		atomic_inc(&zeromount_dirs_count);
++	}
++
++	list_for_each_entry(child, &dir_node->children_names, list) {
++		if (strcmp(child->name, name) == 0) {
++			child_exists = true;
++			break;
++		}
++	}
++
++	if (!child_exists) {
++		child = kzalloc(sizeof(*child), GFP_ATOMIC);
++		if (child) {
++			child->name = kstrdup(name, GFP_ATOMIC);
++			child->d_type = (type == DT_DIR) ? 4 : 8;
++			list_add_tail_rcu(&child->list,
++					  &dir_node->children_names);
++		}
++	}
++
++unlock_out:
++	spin_unlock(&zeromount_lock);
++	kfree(path_copy);
++}
++
++static int zeromount_ioctl_add_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule;
++	char *v_path_raw, *v_path, *r_path;
++	struct path path;
++	unsigned char type;
++	u32 hash;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	r_path = strndup_user(data.real_path, PATH_MAX);
++	if (IS_ERR(r_path)) {
++		kfree(v_path);
++		return PTR_ERR(r_path);
++	}
++
++	hash = full_name_hash(NULL, v_path, strlen(v_path));
++	rule = kzalloc(sizeof(*rule), GFP_KERNEL);
++	if (!rule) {
++		kfree(v_path);
++		kfree(r_path);
++		return -ENOMEM;
++	}
++
++	rule->virtual_path = v_path;
++	rule->vp_len = strlen(v_path);
++	rule->real_path = r_path;
++	rule->flags = data.flags | ZM_FLAG_ACTIVE;
++	rule->is_new = false;
++
++	if (zm_ino_adb == 0)
++		zeromount_refresh_critical_inodes();
++
++	if (kern_path(r_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *inode = d_backing_inode(path.dentry);
++
++		if (inode) {
++			rule->real_ino = inode->i_ino;
++			rule->real_dev = inode->i_sb->s_dev;
++		}
++		path_put(&path);
++	} else {
++		rule->real_ino = 0;
++		rule->real_dev = 0;
++	}
++
++	/* Capture virtual path's dev/ino for maps spoofing.
++	 * Replacement rules use real inode; injected files use
++	 * parent device + generated ino. */
++	zm_enter();
++	if (kern_path(v_path, LOOKUP_FOLLOW, &path) == 0) {
++		struct inode *vinode = d_backing_inode(path.dentry);
++
++		if (vinode) {
++			rule->v_ino = vinode->i_ino;
++			rule->v_dev = vinode->i_sb->s_dev;
++		}
++		path_put(&path);
++	}
++	zm_exit();
++
++	if (rule->v_ino == 0) {
++		rule->v_ino = zeromount_generate_ino(v_path, r_path);
++		{
++			char *parent_copy = kstrdup(v_path, GFP_KERNEL);
++
++			if (parent_copy) {
++				char *slash = strrchr(parent_copy, '/');
++
++				if (slash && slash != parent_copy) {
++					*slash = '\0';
++					zm_enter();
++					if (kern_path(parent_copy, LOOKUP_FOLLOW,
++						      &path) == 0) {
++						struct inode *pinode =
++							d_backing_inode(path.dentry);
++						if (pinode)
++							rule->v_dev = pinode->i_sb->s_dev;
++						path_put(&path);
++					}
++					zm_exit();
++				}
++				kfree(parent_copy);
++			}
++		}
++	}
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_rules_ht, &rule->node, hash);
++	zm_bloom_add(hash);
++	ZM_DBG("bloom: add hash=0x%08x path=%s\n", hash, rule->virtual_path);
++	if (rule->real_ino != 0) {
++		unsigned long ino_key = rule->real_ino ^ rule->real_dev;
++
++		hash_add_rcu(zeromount_ino_ht, &rule->ino_node, ino_key);
++	}
++	list_add_tail(&rule->list, &zeromount_rules_list);
++	atomic_inc(&zeromount_rule_count);
++	spin_unlock(&zeromount_lock);
++
++	type = DT_REG;
++	if (data.flags & ZM_FLAG_IS_DIR)
++		type = DT_DIR;
++
++	if (kern_path(rule->virtual_path, LOOKUP_FOLLOW, &path) == 0) {
++		path_put(&path);
++	} else {
++		zeromount_auto_inject_parent(rule->virtual_path, type, 0);
++		WRITE_ONCE(rule->is_new, true);
++	}
++	zeromount_flush_dcache(rule->virtual_path);
++	return 0;
++}
++
++static void zeromount_cleanup_parent_dir(char *v_path)
++{
++	char *end = v_path + strlen(v_path);
++	char *last_slash, *p;
++	struct zeromount_dir_node *dir_node;
++	struct zeromount_child_name *child, *tmp_child;
++	u32 hash;
++	bool pruned;
++
++	do {
++		pruned = false;
++		last_slash = strrchr(v_path, '/');
++		if (!last_slash || last_slash == v_path)
++			break;
++
++		*last_slash = '\0';
++		hash = full_name_hash(NULL, v_path, strlen(v_path));
++
++		hash_for_each_possible(zeromount_dirs_ht, dir_node,
++				       node, hash) {
++			if (strcmp(dir_node->dir_path, v_path) != 0)
++				continue;
++
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				if (strcmp(child->name, last_slash + 1) == 0) {
++					list_del_rcu(&child->list);
++					call_rcu(&child->rcu,
++						 zeromount_free_child_rcu);
++					break;
++				}
++			}
++
++			if (list_empty(&dir_node->children_names)) {
++				hash_del_rcu(&dir_node->node);
++				atomic_dec(&zeromount_dirs_count);
++				call_rcu(&dir_node->rcu,
++					 zeromount_free_dir_node_rcu);
++				pruned = true;
++			}
++			break;
++		}
++	} while (pruned);
++
++	for (p = v_path; p < end; p++)
++		if (*p == '\0')
++			*p = '/';
++}
++
++static int zeromount_ioctl_del_rule(unsigned long arg)
++{
++	struct zeromount_ioctl_data data;
++	struct zeromount_rule *rule = NULL;
++	struct hlist_node *tmp;
++	char *v_path_raw, *v_path;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
++		return -EFAULT;
++
++	v_path_raw = strndup_user(data.virtual_path, PATH_MAX);
++	if (IS_ERR(v_path_raw))
++		return PTR_ERR(v_path_raw);
++
++	v_path = zeromount_normalize_path(v_path_raw);
++	kfree(v_path_raw);
++	if (!v_path)
++		return -ENOMEM;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		if (strcmp(rule->virtual_path, v_path) == 0) {
++			hash_del_rcu(&rule->node);
++			if (rule->real_ino != 0)
++				hash_del_rcu(&rule->ino_node);
++			list_del(&rule->list);
++			found = true;
++			break;
++		}
++	}
++	if (found)
++		zeromount_cleanup_parent_dir(v_path);
++	if (found)
++		atomic_dec(&zeromount_rule_count);
++	zm_bloom_rebuild();
++	spin_unlock(&zeromount_lock);
++
++	if (found && rule)
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++
++	kfree(v_path);
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_clear_rules(void)
++{
++	struct zeromount_rule *rule;
++	struct zeromount_uid_node *uid_node;
++	struct hlist_node *tmp;
++	int bkt;
++
++	spin_lock(&zeromount_lock);
++
++	hash_for_each_safe(zeromount_rules_ht, bkt, tmp, rule, node) {
++		hash_del_rcu(&rule->node);
++		if (rule->real_ino != 0)
++			hash_del_rcu(&rule->ino_node);
++		list_del(&rule->list);
++		call_rcu(&rule->rcu, zeromount_free_rule_rcu);
++	}
++
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, uid_node, node) {
++		hash_del_rcu(&uid_node->node);
++		kfree_rcu(uid_node, rcu);
++	}
++
++	{
++		struct zeromount_dir_node *dir_node;
++		struct zeromount_child_name *child, *tmp_child;
++		int bkt2;
++		struct hlist_node *tmp2;
++
++		hash_for_each_safe(zeromount_dirs_ht, bkt2, tmp2,
++				   dir_node, node) {
++			hash_del_rcu(&dir_node->node);
++			atomic_dec(&zeromount_dirs_count);
++			list_for_each_entry_safe(child, tmp_child,
++						 &dir_node->children_names,
++						 list) {
++				list_del_rcu(&child->list);
++				call_rcu(&child->rcu,
++					 zeromount_free_child_rcu);
++			}
++			call_rcu(&dir_node->rcu,
++				 zeromount_free_dir_node_rcu);
++		}
++	}
++
++	atomic_set(&zeromount_rule_count, 0);
++	bitmap_zero(zm_bloom, ZM_BLOOM_BITS);
++	spin_unlock(&zeromount_lock);
++	return 0;
++}
++
++static int zeromount_ioctl_list_rules(unsigned long arg)
++{
++	struct zeromount_rule *rule;
++	char *kbuf;
++	int ret = 0;
++	size_t len = 0;
++	size_t remaining;
++	char __user *ubuf = (char __user *)arg;
++
++	kbuf = vmalloc(MAX_LIST_BUFFER_SIZE);
++	if (!kbuf)
++		return -ENOMEM;
++
++	memset(kbuf, 0, MAX_LIST_BUFFER_SIZE);
++	spin_lock(&zeromount_lock);
++
++	list_for_each_entry(rule, &zeromount_rules_list, list) {
++		remaining = MAX_LIST_BUFFER_SIZE - len;
++		if (remaining <= 1) {
++			ret = -ENOBUFS;
++			break;
++		}
++		len += scnprintf(kbuf + len, remaining, "%s->%s\n",
++				 rule->real_path, rule->virtual_path);
++	}
++
++	spin_unlock(&zeromount_lock);
++
++	if (ret == -ENOBUFS) {
++		vfree(kbuf);
++		return ret;
++	}
++
++	if (copy_to_user(ubuf, kbuf, len))
++		ret = -EFAULT;
++	else
++		ret = len;
++
++	vfree(kbuf);
++	return ret;
++}
++
++static int zeromount_ioctl_add_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++	if (zeromount_is_uid_blocked(uid))
++		return -EEXIST;
++
++	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return -ENOMEM;
++
++	entry->uid = uid;
++
++	spin_lock(&zeromount_lock);
++	hash_add_rcu(zeromount_uid_ht, &entry->node, uid);
++	spin_unlock(&zeromount_lock);
++
++	return 0;
++}
++
++static int zeromount_ioctl_del_uid(unsigned long arg)
++{
++	unsigned int uid;
++	struct zeromount_uid_node *entry;
++	struct hlist_node *tmp;
++	int bkt;
++	bool found = false;
++
++	if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
++		return -EFAULT;
++
++	spin_lock(&zeromount_lock);
++	hash_for_each_safe(zeromount_uid_ht, bkt, tmp, entry, node) {
++		if (entry->uid == uid) {
++			hash_del_rcu(&entry->node);
++			found = true;
++			break;
++		}
++	}
++	spin_unlock(&zeromount_lock);
++
++	if (found && entry)
++		kfree_rcu(entry, rcu);
++
++	return found ? 0 : -ENOENT;
++}
++
++static int zeromount_ioctl_enable(void)
++{
++	atomic_set(&zeromount_enabled, 1);
++	return 0;
++}
++
++static int zeromount_ioctl_disable(void)
++{
++	atomic_set(&zeromount_enabled, 0);
++	return 0;
++}
++
++static long zeromount_ioctl(struct file *filp, unsigned int cmd,
++			    unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) != ZEROMOUNT_MAGIC_CODE)
++		return -ENOTTY;
++
++	if (cmd != ZEROMOUNT_IOC_GET_VERSION) {
++		if (!capable(CAP_SYS_ADMIN))
++			return -EPERM;
++	}
++
++	switch (cmd) {
++	case ZEROMOUNT_IOC_GET_VERSION:	return ZEROMOUNT_VERSION;
++	case ZEROMOUNT_IOC_ADD_RULE:	return zeromount_ioctl_add_rule(arg);
++	case ZEROMOUNT_IOC_DEL_RULE:	return zeromount_ioctl_del_rule(arg);
++	case ZEROMOUNT_IOC_CLEAR_ALL:	return zeromount_ioctl_clear_rules();
++	case ZEROMOUNT_IOC_ADD_UID:	return zeromount_ioctl_add_uid(arg);
++	case ZEROMOUNT_IOC_DEL_UID:	return zeromount_ioctl_del_uid(arg);
++	case ZEROMOUNT_IOC_GET_LIST:	return zeromount_ioctl_list_rules(arg);
++	case ZEROMOUNT_IOC_ENABLE:	return zeromount_ioctl_enable();
++	case ZEROMOUNT_IOC_DISABLE:	return zeromount_ioctl_disable();
++	case ZEROMOUNT_IOC_REFRESH:
++		zeromount_force_refresh_all();
++		return 0;
++	case ZEROMOUNT_IOC_GET_STATUS:	return atomic_read(&zeromount_enabled);
++	default:			return -EINVAL;
++	}
++}
++
++static struct kobject *zeromount_kobj;
++
++static ssize_t debug_show(struct kobject *kobj, struct kobj_attribute *attr,
++			  char *buf)
++{
++	return sprintf(buf, "%d\n", zeromount_debug_level);
++}
++
++static ssize_t debug_store(struct kobject *kobj, struct kobj_attribute *attr,
++			   const char *buf, size_t count)
++{
++	int val;
++
++	if (kstrtoint(buf, 10, &val) < 0)
++		return -EINVAL;
++	if (val < 0 || val > 2)
++		return -EINVAL;
++	zeromount_debug_level = val;
++	return count;
++}
++
++static struct kobj_attribute debug_attr =
++	__ATTR(debug, 0600, debug_show, debug_store);
++
++static struct attribute *zeromount_attrs[] = {
++	&debug_attr.attr,
++	NULL,
++};
++
++static struct attribute_group zeromount_attr_group = {
++	.attrs = zeromount_attrs,
++};
++
++static int zeromount_dev_open(struct inode *inode, struct file *file)
++{
++	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
++		return -EPERM;
++	return 0;
++}
++
++static const struct file_operations zeromount_fops = {
++	.owner		= THIS_MODULE,
++	.open		= zeromount_dev_open,
++	.unlocked_ioctl	= zeromount_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl	= zeromount_ioctl,
++#endif
++};
++
++static struct miscdevice zeromount_device = {
++	.minor	= MISC_DYNAMIC_MINOR,
++	.name	= "zeromount",
++	.fops	= &zeromount_fops,
++	.mode	= 0600,
++};
++
++static int zeromount_reboot_notify(struct notifier_block *nb,
++				   unsigned long action, void *data)
++{
++	atomic_set(&zeromount_enabled, 0);
++	synchronize_rcu();
++	return NOTIFY_OK;
++}
++
++static struct notifier_block zeromount_reboot_nb = {
++	.notifier_call = zeromount_reboot_notify,
++};
++
++static int __init __used zeromount_init(void)
++{
++	int ret;
++
++	spin_lock_init(&zeromount_lock);
++	register_reboot_notifier(&zeromount_reboot_nb);
++
++	ret = misc_register(&zeromount_device);
++	if (ret)
++		return ret;
++
++	zeromount_kobj = kobject_create_and_add("zeromount", kernel_kobj);
++	if (zeromount_kobj) {
++		ret = sysfs_create_group(zeromount_kobj,
++					&zeromount_attr_group);
++		if (ret)
++			pr_warn("ZeroMount: sysfs group creation failed: %d\n",
++				ret);
++	}
++
++	ZM_INFO("Loaded (debug=%d)\n", zeromount_debug_level);
++	return 0;
++}
++fs_initcall(zeromount_init);
++
+diff '--color=auto' -ruN '--exclude=.git' work-50-base/include/linux/zeromount.h work/include/linux/zeromount.h
+--- work-50-base/include/linux/zeromount.h	1970-01-01 01:00:00.000000000 +0100
++++ work/include/linux/zeromount.h	2026-03-01 06:09:41.416477792 +0100
+@@ -0,0 +1,200 @@
++#ifndef _LINUX_ZEROMOUNT_H
++#define _LINUX_ZEROMOUNT_H
++
++#include <linux/types.h>
++#include <linux/list.h>
++#include <linux/hashtable.h>
++#include <linux/spinlock.h>
++#include <linux/limits.h>
++#include <linux/atomic.h>
++#include <linux/uidgid.h>
++#include <linux/stat.h>
++#include <linux/ioctl.h>
++#include <linux/rcupdate.h>
++#include <linux/printk.h>
++#include <linux/sched.h>
++#include <linux/bitops.h>
++
++#define ZM_BLOOM_BITS     4096
++#define ZM_BLOOM_SHIFT    12
++#define ZM_BLOOM_MASK     (ZM_BLOOM_BITS - 1)
++
++/* Per-task recursion guard using android_oem_data1 bit 0.
++ * Survives CPU migration -- no preemption constraints needed. */
++#ifdef CONFIG_ANDROID_VENDOR_OEM_DATA
++#define ZM_RECURSIVE_BIT 0
++
++static inline void zm_enter(void)
++{
++	set_bit(ZM_RECURSIVE_BIT,
++		(unsigned long *)&current->android_oem_data1);
++}
++
++static inline void zm_exit(void)
++{
++	clear_bit(ZM_RECURSIVE_BIT,
++		  (unsigned long *)&current->android_oem_data1);
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return test_bit(ZM_RECURSIVE_BIT,
++			(unsigned long *)&current->android_oem_data1);
++}
++#else
++#define ZM_RECURSIVE_MARKER ((void *)0x5A4D)
++
++/* Only claim journal_info if it is free — avoids clobbering jbd2 handles
++ * held by user processes doing ext4 I/O. If already occupied, we treat
++ * the call as a no-op; zm_is_recursive() returns false so ZeroMount
++ * proceeds normally, which is safe since the occupied handle means we
++ * are in a filesystem transaction context where redirection is unwanted. */
++static inline void zm_enter(void)
++{
++	if (!current->journal_info)
++		current->journal_info = ZM_RECURSIVE_MARKER;
++}
++
++static inline void zm_exit(void)
++{
++	if (current->journal_info == ZM_RECURSIVE_MARKER)
++		current->journal_info = NULL;
++}
++
++static inline bool zm_is_recursive(void)
++{
++	return current->journal_info == ZM_RECURSIVE_MARKER;
++}
++#endif
++
++extern int zeromount_debug_level;
++
++#define ZM_LOG(level, fmt, ...) \
++	do { \
++		if (zeromount_debug_level >= (level) && printk_ratelimit()) \
++			pr_info("ZeroMount: " fmt, ##__VA_ARGS__); \
++	} while (0)
++
++#define ZM_TRACE(fmt, ...) ZM_LOG(3, fmt, ##__VA_ARGS__)
++#define ZM_DBG(fmt, ...)  ZM_LOG(2, fmt, ##__VA_ARGS__)
++#define ZM_INFO(fmt, ...) ZM_LOG(1, fmt, ##__VA_ARGS__)
++#define ZM_ERR(fmt, ...)  pr_err("ZeroMount: " fmt, ##__VA_ARGS__)
++
++#define ZEROMOUNT_MAGIC_CODE	0x5A
++#define ZEROMOUNT_VERSION	1
++#define ZEROMOUNT_HASH_BITS	10
++#define ZM_FLAG_ACTIVE		(1 << 0)
++#define ZM_FLAG_IS_DIR		(1 << 7)
++#define ZEROMOUNT_MAGIC_POS	0x7000000000000000ULL
++
++#define ZEROMOUNT_IOC_MAGIC	ZEROMOUNT_MAGIC_CODE
++#define ZEROMOUNT_IOC_ADD_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 1, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_DEL_RULE	_IOW(ZEROMOUNT_IOC_MAGIC, 2, struct zeromount_ioctl_data)
++#define ZEROMOUNT_IOC_CLEAR_ALL	_IO(ZEROMOUNT_IOC_MAGIC, 3)
++#define ZEROMOUNT_IOC_GET_VERSION _IOR(ZEROMOUNT_IOC_MAGIC, 4, int)
++#define ZEROMOUNT_IOC_ADD_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 5, unsigned int)
++#define ZEROMOUNT_IOC_DEL_UID	_IOW(ZEROMOUNT_IOC_MAGIC, 6, unsigned int)
++#define ZEROMOUNT_IOC_GET_LIST	_IOR(ZEROMOUNT_IOC_MAGIC, 7, int)
++#define ZEROMOUNT_IOC_ENABLE	_IO(ZEROMOUNT_IOC_MAGIC, 8)
++#define ZEROMOUNT_IOC_DISABLE	_IO(ZEROMOUNT_IOC_MAGIC, 9)
++#define ZEROMOUNT_IOC_REFRESH	_IO(ZEROMOUNT_IOC_MAGIC, 10)
++#define ZEROMOUNT_IOC_GET_STATUS _IOR(ZEROMOUNT_IOC_MAGIC, 11, int)
++#define MAX_LIST_BUFFER_SIZE	(64 * 1024)
++
++struct zeromount_ioctl_data {
++	char __user *virtual_path;
++	char __user *real_path;
++	unsigned int flags;
++};
++
++struct zeromount_rule {
++	struct hlist_node node;
++	struct hlist_node ino_node;
++	struct list_head list;
++	size_t vp_len;
++	char *virtual_path;
++	char *real_path;
++	unsigned long real_ino;
++	dev_t real_dev;
++	unsigned long v_ino;
++	dev_t v_dev;
++	bool is_new;
++	u32 flags;
++	struct rcu_head rcu;
++};
++
++struct zeromount_dir_node {
++	struct hlist_node node;
++	char *dir_path;
++	struct list_head children_names;
++	struct rcu_head rcu;
++};
++
++struct zeromount_child_name {
++	struct list_head list;
++	char *name;
++	unsigned char d_type;
++	struct rcu_head rcu;
++};
++
++struct zeromount_uid_node {
++	uid_t uid;
++	struct hlist_node node;
++	struct rcu_head rcu;
++};
++
++extern DECLARE_HASHTABLE(zeromount_rules_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_dirs_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_uid_ht, ZEROMOUNT_HASH_BITS);
++extern DECLARE_HASHTABLE(zeromount_ino_ht, ZEROMOUNT_HASH_BITS);
++extern struct list_head zeromount_rules_list;
++extern spinlock_t zeromount_lock;
++
++#ifdef CONFIG_ZEROMOUNT
++extern atomic_t zeromount_enabled;
++
++bool zeromount_should_skip(void);
++char *zeromount_resolve_path(const char *pathname);
++char *zeromount_build_absolute_path(int dfd, const char *name);
++struct filename *zeromount_getname_hook(struct filename *name);
++void zeromount_inject_dents_common(struct file *file, void __user **dirent,
++				   int *count, loff_t *pos, int compat);
++void zeromount_inject_dents64(struct file *file, void __user **dirent,
++			      int *count, loff_t *pos);
++void zeromount_inject_dents(struct file *file, void __user **dirent,
++			    int *count, loff_t *pos);
++char *zeromount_get_virtual_path_for_inode(struct inode *inode);
++char *zeromount_get_static_vpath(struct inode *inode);
++void zeromount_spoof_mmap_metadata(const struct inode *inode, dev_t *dev,
++				   unsigned long *ino);
++bool zeromount_is_traversal_allowed(struct inode *inode, int mask);
++bool zeromount_is_injected_file(struct inode *inode);
++bool zeromount_is_uid_blocked(uid_t uid);
++int zeromount_spoof_statfs(const char __user *pathname, struct kstatfs *buf);
++ssize_t zeromount_spoof_xattr(struct dentry *dentry, const char *name,
++			      void *value, size_t size);
++#else
++static inline bool zeromount_should_skip(void) { return true; }
++static inline char *zeromount_resolve_path(const char *p) { return NULL; }
++static inline char *zeromount_build_absolute_path(int dfd, const char *name) { return NULL; }
++static inline struct filename *zeromount_getname_hook(struct filename *name) { return name; }
++static inline void zeromount_inject_dents_common(struct file *f, void __user **d,
++						 int *c, loff_t *p, int compat) {}
++static inline void zeromount_inject_dents64(struct file *f, void __user **d,
++					    int *c, loff_t *p) {}
++static inline void zeromount_inject_dents(struct file *f, void __user **d,
++					  int *c, loff_t *p) {}
++static inline char *zeromount_get_virtual_path_for_inode(struct inode *inode) { return NULL; }
++static inline char *zeromount_get_static_vpath(struct inode *inode) { return NULL; }
++static inline void zeromount_spoof_mmap_metadata(const struct inode *inode,
++						 dev_t *dev,
++						 unsigned long *ino) {}
++static inline bool zeromount_is_traversal_allowed(struct inode *inode, int mask) { return false; }
++static inline bool zeromount_is_injected_file(struct inode *inode) { return false; }
++static inline bool zeromount_is_uid_blocked(uid_t uid) { return false; }
++static inline int zeromount_spoof_statfs(const char __user *p, struct kstatfs *b) { return 0; }
++static inline ssize_t zeromount_spoof_xattr(struct dentry *d, const char *n,
++					    void *v, size_t s) { return -EOPNOTSUPP; }
++#endif
++
++#endif /* _LINUX_ZEROMOUNT_H */


### PR DESCRIPTION
Add ZeroMount patch integration for all kernel versions (5.10~6.12). ZeroMount provides path redirection and virtual file injection without mounting filesystems, gated behind add_zeromount + enable_susfs.

Patches sourced from Enginex0/Super-Builders, identical across variants.