### PR TITLE
backport CVE-2026-43499 rtmutex fix chain

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Unified patch payloads intentionally preserve space-prefixed blank context
+# lines and kernel-style tab indentation.
+security_patch/*.patch -whitespace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       enable_susfs:
         required: true
         type: boolean
@@ -105,6 +109,7 @@ jobs:
           echo "BBG 补丁      : ${{ inputs.use_bbg }}"
           echo "KPM 功能      : ${{ inputs.use_kpm }}"
           echo "Re-Kernel     : ${{ inputs.use_rekernel }}"
+          echo "CVE-2026-43499: ${{ inputs.cve_2026_43499_patch }}"
           echo "Droidspaces   : ${{ inputs.droidspaces }}"
           echo "NTSync        : ${{ inputs.droidspaces_ntsync }}"
           echo "产物上传模式  : ${{ inputs.artifact_upload_mode }}"
@@ -348,6 +353,16 @@ jobs:
           fi
           echo "ACTUAL_SUBLEVEL=$ACTUAL_SUBLEVEL" >> $GITHUB_ENV
           echo "实际子版本号: $ACTUAL_SUBLEVEL"
+
+      # 以同步后的实际 SUBLEVEL 判断，避免对已包含上游修复的 LTS 重复打补丁
+      - name: 自动应用 CVE-2026-43499 rtmutex 修复链
+        if: inputs.cve_2026_43499_patch
+        working-directory: ${{ env.KERNEL_ROOT }}/common
+        run: |
+          bash "$GITHUB_WORKSPACE/security_patch/apply_cve_2026_43499.sh" \
+            "${{ inputs.kernel_version }}" \
+            "$ACTUAL_SUBLEVEL" \
+            "$GITHUB_WORKSPACE/security_patch"
 
       - name: 修复 glibc 2.38 兼容性
         working-directory: ${{ env.KERNEL_ROOT }}/common

--- a/.github/workflows/kernel-a12-5-10.yml
+++ b/.github/workflows/kernel-a12-5-10.yml
@@ -75,6 +75,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -105,6 +110,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         required: false
         type: boolean
@@ -214,6 +223,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/kernel-a13-5-15.yml
+++ b/.github/workflows/kernel-a13-5-15.yml
@@ -75,6 +75,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -105,6 +110,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         required: false
         type: boolean
@@ -187,6 +196,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/kernel-a14-6-1.yml
+++ b/.github/workflows/kernel-a14-6-1.yml
@@ -75,6 +75,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -105,6 +110,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         required: false
         type: boolean
@@ -193,6 +202,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: false
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/kernel-a15-6-6.yml
+++ b/.github/workflows/kernel-a15-6-6.yml
@@ -75,6 +75,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -110,6 +115,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         required: false
         type: boolean
@@ -185,6 +194,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: ${{ inputs.supp_op || false }}
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/kernel-a16-6-12.yml
+++ b/.github/workflows/kernel-a16-6-12.yml
@@ -73,6 +73,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -108,6 +113,10 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         required: false
         type: boolean
@@ -163,6 +172,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: ${{ inputs.supp_op || false }}
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/kernel-custom.yml
+++ b/.github/workflows/kernel-custom.yml
@@ -100,6 +100,11 @@ on:
         required: false
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        required: false
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         required: true
@@ -204,6 +209,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel || false }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       supp_op: ${{ inputs.supp_op || false }}
       enable_susfs: ${{ !inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces || 'off' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,10 @@ on:
         description: "启用 Re-Kernel 驱动"
         type: boolean
         default: false
+      cve_2026_43499_patch:
+        description: "应用 CVE-2026-43499 rtmutex 修复链"
+        type: boolean
+        default: true
       cancel_susfs:
         description: "禁用 SUSFS"
         type: boolean
@@ -145,6 +149,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces }}
       artifact_upload_mode: "上传全部"
@@ -164,6 +169,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces }}
       artifact_upload_mode: "上传全部"
@@ -183,6 +189,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces }}
       artifact_upload_mode: "上传全部"
@@ -202,6 +209,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces }}
       artifact_upload_mode: "上传全部"
@@ -221,6 +229,7 @@ jobs:
       use_bbg: ${{ inputs.use_bbg }}
       use_kpm: ${{ inputs.use_kpm }}
       use_rekernel: ${{ inputs.use_rekernel }}
+      cve_2026_43499_patch: ${{ inputs.cve_2026_43499_patch }}
       cancel_susfs: ${{ inputs.cancel_susfs }}
       droidspaces: ${{ inputs.droidspaces }}
       artifact_upload_mode: "上传全部"

--- a/security_patch/apply_cve_2026_43499.sh
+++ b/security_patch/apply_cve_2026_43499.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kernel_version="${1:-}"
+kernel_sublevel="${2:-}"
+patch_dir="${3:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+rtmutex_file="kernel/locking/rtmutex.c"
+
+if [ -z "$kernel_version" ] || [ -z "$kernel_sublevel" ]; then
+  echo "Usage: $0 <kernel-version> <actual-sublevel> [patch-dir]" >&2
+  exit 2
+fi
+
+if [ ! -f "$rtmutex_file" ]; then
+  echo "ERROR: $rtmutex_file not found. Run this from kernel_platform/common." >&2
+  exit 1
+fi
+
+try_apply_patch() {
+  local patch_file="$1"
+  local log_file
+
+  log_file="$(mktemp "${TMPDIR:-/tmp}/cve-2026-43499.XXXXXX")"
+
+  # Never let patch auto-reverse a partially matching helper patch.  A
+  # partially backported Android tree must use the explicit, idempotent
+  # fallback below instead.
+  if patch --batch --forward --dry-run -p1 < "$patch_file" >"$log_file" 2>&1; then
+    patch --batch --forward -p1 < "$patch_file"
+    rm -f "$log_file"
+    return 0
+  fi
+
+  cat "$log_file" >&2
+  rm -f "$log_file"
+  return 1
+}
+
+replace_proxy_cleanup_condition() {
+  local target=""
+  local candidate
+  local tmp_file
+
+  for candidate in kernel/locking/rtmutex_api.c kernel/locking/rtmutex.c; do
+    if [ -f "$candidate" ] &&
+       grep -q 'ret = __rt_mutex_start_proxy_lock' "$candidate"; then
+      target="$candidate"
+      break
+    fi
+  done
+
+  if [ -z "$target" ]; then
+    # Older 5.15-style rtmutex trees have no proxy-lock wrapper, so the
+    # ret < 0 follow-up is not applicable there.
+    echo "CVE-2026-53163 proxy cleanup path is absent; no change required."
+    return 0
+  fi
+
+  if grep -q 'if (unlikely(ret < 0))' "$target"; then
+    echo "CVE-2026-53163 proxy cleanup fix already present."
+    return 0
+  fi
+
+  tmp_file="$(mktemp)"
+  if ! awk '
+    /ret = __rt_mutex_start_proxy_lock/ { in_proxy_start = 1 }
+    in_proxy_start && /if \(unlikely\(ret\)\)/ {
+      sub(/if \(unlikely\(ret\)\)/, "if (unlikely(ret < 0))")
+      replaced++
+      in_proxy_start = 0
+    }
+    { print }
+    END { if (replaced != 1) exit 42 }
+  ' "$target" > "$tmp_file"; then
+    rm -f "$tmp_file"
+    echo "ERROR: failed to locate the proxy cleanup condition in $target." >&2
+    return 1
+  fi
+
+  mv "$tmp_file" "$target"
+  echo "Applied CVE-2026-53163 proxy cleanup fix to $target."
+}
+
+ensure_remove_waiter_null_guard() {
+  local tmp_file
+
+  if grep -q 'if (!waiter_task) /\* never enqueued \*/' "$rtmutex_file"; then
+    echo "CVE-2026-53163 remove_waiter() NULL guard already present."
+    return 0
+  fi
+
+  tmp_file="$(mktemp)"
+  if ! awk '
+    /^static .*remove_waiter\(/ { in_remove_waiter = 1 }
+    {
+      print
+      if (in_remove_waiter && /lockdep_assert_held\(&lock->wait_lock\);/) {
+        match($0, /^[[:space:]]*/)
+        indent = substr($0, RSTART, RLENGTH)
+        print ""
+        print indent "if (!waiter_task) /* never enqueued */"
+        print indent "\treturn;"
+        inserted++
+        in_remove_waiter = 0
+      }
+    }
+    END { if (inserted != 1) exit 42 }
+  ' "$rtmutex_file" > "$tmp_file"; then
+    rm -f "$tmp_file"
+    echo "ERROR: failed to locate remove_waiter() in $rtmutex_file." >&2
+    return 1
+  fi
+
+  mv "$tmp_file" "$rtmutex_file"
+  echo "Applied CVE-2026-53163 remove_waiter() NULL guard."
+}
+
+ensure_followup_fixes() {
+  ensure_remove_waiter_null_guard
+  replace_proxy_cleanup_condition
+}
+
+append_file() {
+  local target="$1"
+  local insert_file="$2"
+  local tmp_file
+
+  tmp_file="$(mktemp)"
+  awk -v insert_file="$insert_file" '
+    { print }
+    END {
+      while ((getline line < insert_file) > 0)
+        print line
+      close(insert_file)
+    }
+  ' "$target" > "$tmp_file"
+  mv "$tmp_file" "$target"
+}
+
+insert_file_before_last_endif() {
+  local target="$1"
+  local insert_file="$2"
+  local tmp_file
+
+  tmp_file="$(mktemp)"
+  awk -v insert_file="$insert_file" '
+    { lines[NR] = $0; if ($0 ~ /^#endif/) last_endif = NR }
+    function emit() {
+      while ((getline line < insert_file) > 0)
+        print line
+      close(insert_file)
+    }
+    END {
+      for (i = 1; i <= NR; i++) {
+        if (i == last_endif)
+          emit()
+        print lines[i]
+      }
+      if (!last_endif)
+        emit()
+    }
+  ' "$target" > "$tmp_file"
+  mv "$tmp_file" "$target"
+}
+
+install_scoped_guard_support() {
+  local tmp_file
+
+  if [ ! -f "$patch_dir/scoped_guard_cleanup.h" ]; then
+    echo "ERROR: scoped_guard cleanup header not found." >&2
+    return 1
+  fi
+
+  if [ ! -f include/linux/cleanup.h ] ||
+     ! grep -q 'scoped_guard' include/linux/cleanup.h; then
+    cp "$patch_dir/scoped_guard_cleanup.h" include/linux/cleanup.h
+  fi
+
+  if [ -f include/linux/compiler_attributes.h ]; then
+    if ! grep -q '^#define __cleanup(func)' include/linux/compiler_attributes.h; then
+      insert_file_before_last_endif include/linux/compiler_attributes.h "$patch_dir/scoped_guard_compiler_cleanup.txt"
+    fi
+  elif [ -f include/linux/compiler.h ]; then
+    if ! grep -q '^#define __cleanup(func)' include/linux/compiler.h; then
+      append_file include/linux/compiler.h "$patch_dir/scoped_guard_compiler_cleanup.txt"
+    fi
+  else
+    echo "ERROR: neither compiler_attributes.h nor compiler.h found." >&2
+    return 1
+  fi
+
+  if [ -f include/linux/compiler-clang.h ] &&
+     ! grep -q 'Clang prior to 17' include/linux/compiler-clang.h; then
+    append_file include/linux/compiler-clang.h "$patch_dir/scoped_guard_compiler_clang.txt"
+  fi
+
+  if ! grep -q '#include <linux/cleanup.h>' include/linux/spinlock.h; then
+    tmp_file="$(mktemp)"
+    awk '
+      { print }
+      !done && /^#include <linux\/lockdep.h>/ {
+        print "#include <linux/cleanup.h>"
+        done = 1
+      }
+      !done && /^#include <linux\/bottom_half.h>/ {
+        print "#include <linux/cleanup.h>"
+        done = 1
+      }
+      END {
+        if (!done)
+          print "#include <linux/cleanup.h>"
+      }
+    ' include/linux/spinlock.h > "$tmp_file"
+    mv "$tmp_file" include/linux/spinlock.h
+  fi
+
+  if ! grep -q 'DEFINE_LOCK_GUARD_1(raw_spinlock' include/linux/spinlock.h; then
+    tmp_file="$(mktemp)"
+    awk -v insert_file="$patch_dir/scoped_guard_spinlock_guards.txt" '
+      function emit() {
+        while ((getline line < insert_file) > 0)
+          print line
+        close(insert_file)
+      }
+      !done && /^#undef __LINUX_INSIDE_SPINLOCK_H/ {
+        emit()
+        done = 1
+      }
+      !done && /^#endif .*__LINUX_SPINLOCK_H/ {
+        emit()
+        done = 1
+      }
+      { print }
+      END {
+        if (!done)
+          emit()
+      }
+    ' include/linux/spinlock.h > "$tmp_file"
+    mv "$tmp_file" include/linux/spinlock.h
+  fi
+}
+
+ensure_scoped_guard_support() {
+  if grep -qs 'DEFINE_LOCK_GUARD_1(raw_spinlock' include/linux/spinlock.h &&
+     grep -qs 'scoped_guard' include/linux/cleanup.h; then
+    return 0
+  fi
+
+  local guard_patch="$patch_dir/cve-2026-43499-guards.patch"
+  if [ ! -f "$guard_patch" ]; then
+    echo "ERROR: scoped_guard helper patch not found: $guard_patch" >&2
+    return 1
+  fi
+
+  echo "Applying scoped_guard/raw_spinlock helper backport..."
+  if try_apply_patch "$guard_patch"; then
+    return 0
+  fi
+
+  echo "Patch helper did not match; installing scoped_guard support directly..."
+  install_scoped_guard_support
+}
+
+ensure_rtmutex_c99() {
+  case "$kernel_version" in
+    5.10|5.15)
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  local makefile="kernel/locking/Makefile"
+  if [ ! -f "$makefile" ]; then
+    echo "ERROR: $makefile not found." >&2
+    return 1
+  fi
+
+  local objects=(
+    rtmutex.o
+    rtmutex_api.o
+    rwsem.o
+    ww_rt_mutex.o
+    spinlock_rt.o
+  )
+  local additions_file
+  local object
+  local escaped_object
+  additions_file="$(mktemp)"
+
+  for object in "${objects[@]}"; do
+    escaped_object="${object//./\\.}"
+    if ! grep -q "^CFLAGS_REMOVE_${escaped_object} .*std=gnu89" "$makefile"; then
+      echo "CFLAGS_REMOVE_${object} += -std=gnu89" >> "$additions_file"
+    fi
+    if ! grep -q "^CFLAGS_${escaped_object} .*std=gnu99" "$makefile"; then
+      echo "CFLAGS_${object} += -std=gnu99" >> "$additions_file"
+    fi
+  done
+
+  if [ ! -s "$additions_file" ]; then
+    rm -f "$additions_file"
+    return 0
+  fi
+
+  echo "Forcing rtmutex include units to gnu99 for scoped_guard on 5.x..."
+  local tmp_makefile
+  tmp_makefile="$(mktemp)"
+  awk -v insert_file="$additions_file" '
+    function emit() {
+      while ((getline line < insert_file) > 0)
+        print line
+      close(insert_file)
+    }
+    !done && /^obj-\$\(CONFIG_RT_MUTEXES\).*rtmutex/ {
+      emit()
+      done = 1
+    }
+    { print }
+    END {
+      if (!done)
+        emit()
+    }
+  ' "$makefile" > "$tmp_makefile"
+  mv "$tmp_makefile" "$makefile"
+  rm -f "$additions_file"
+}
+
+patch_chain_is_required() {
+  # The second threshold includes CVE-2026-53163, which fixes the regression
+  # introduced by the original CVE-2026-43499 backport.
+  case "$kernel_version" in
+    5.10|5.15)
+      # Neither maintained Android 5.x line received the upstream backport.
+      return 0
+      ;;
+    6.1)
+      (( kernel_sublevel < 177 ))
+      ;;
+    6.6)
+      (( kernel_sublevel < 144 ))
+      ;;
+    6.12)
+      (( kernel_sublevel < 95 ))
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+case "$kernel_version" in
+  5.10|5.15)
+    ;;
+  6.1|6.6|6.12)
+    if [[ ! "$kernel_sublevel" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: non-numeric SUBLEVEL for $kernel_version: $kernel_sublevel" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "CVE-2026-43499: $kernel_version is outside this repository's supported GKI lines; skipping."
+    exit 0
+    ;;
+esac
+
+if ! patch_chain_is_required; then
+  echo "CVE-2026-43499/CVE-2026-53163 fix chain is upstream in $kernel_version.$kernel_sublevel; skipping."
+  exit 0
+fi
+
+case "$kernel_version" in
+  5.10)
+    primary_patch="$patch_dir/cve-2026-43499-rtmutex-5.10.patch"
+    fallback_patch="$patch_dir/cve-2026-43499-rtmutex-5.15.patch"
+    ;;
+  5.15)
+    primary_patch="$patch_dir/cve-2026-43499-rtmutex-5.15.patch"
+    fallback_patch=""
+    ;;
+  6.1|6.6)
+    primary_patch="$patch_dir/cve-2026-43499-rtmutex-6.1-6.6.patch"
+    fallback_patch=""
+    ;;
+  6.12)
+    primary_patch="$patch_dir/cve-2026-43499-rtmutex-6.12.patch"
+    fallback_patch=""
+    ;;
+  *)
+    echo "ERROR: unsupported kernel version for CVE-2026-43499 patch: $kernel_version" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$primary_patch" ]; then
+  echo "ERROR: patch file not found: $primary_patch" >&2
+  exit 1
+fi
+
+echo "Applying the CVE-2026-43499 rtmutex fix chain for kernel $kernel_version..."
+
+if grep -q 'struct task_struct \*waiter_task = waiter->task;' "$rtmutex_file"; then
+  echo "CVE-2026-43499 rtmutex fix already present."
+  if grep -q 'scoped_guard(raw_spinlock' "$rtmutex_file"; then
+    ensure_scoped_guard_support
+    ensure_rtmutex_c99
+  fi
+  ensure_followup_fixes
+  echo "CVE-2026-43499/CVE-2026-53163 fix chain is complete."
+  exit 0
+fi
+
+ensure_scoped_guard_support
+ensure_rtmutex_c99
+
+if try_apply_patch "$primary_patch"; then
+  echo "CVE-2026-43499 rtmutex fix applied."
+  ensure_followup_fixes
+  echo "CVE-2026-43499/CVE-2026-53163 fix chain is complete."
+  exit 0
+fi
+
+if [ -n "${fallback_patch:-}" ] && [ -f "$fallback_patch" ]; then
+  echo "Primary patch did not match; trying fallback shape: $(basename "$fallback_patch")"
+  if try_apply_patch "$fallback_patch"; then
+    echo "CVE-2026-43499 rtmutex fix applied with fallback patch."
+    ensure_followup_fixes
+    echo "CVE-2026-43499/CVE-2026-53163 fix chain is complete."
+    exit 0
+  fi
+fi
+
+echo "ERROR: failed to apply CVE-2026-43499 rtmutex fix." >&2
+exit 1

--- a/security_patch/cve-2026-43499-guards.patch
+++ b/security_patch/cve-2026-43499-guards.patch
@@ -1,0 +1,259 @@
+diff -uprN -x .DS_Store a/include/linux/cleanup.h b/include/linux/cleanup.h
+--- a/include/linux/cleanup.h	1970-01-01 08:00:00
++++ b/include/linux/cleanup.h	2026-07-09 15:40:07
+@@ -0,0 +1,171 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __LINUX_GUARDS_H
++#define __LINUX_GUARDS_H
++
++#include <linux/compiler.h>
++
++/*
++ * DEFINE_FREE(name, type, free):
++ *	simple helper macro that defines the required wrapper for a __free()
++ *	based cleanup function. @free is an expression using '_T' to access
++ *	the variable.
++ *
++ * __free(name):
++ *	variable attribute to add a scoped based cleanup to the variable.
++ *
++ * no_free_ptr(var):
++ *	like a non-atomic xchg(var, NULL), such that the cleanup function will
++ *	be inhibited -- provided it sanely deals with a NULL value.
++ *
++ * return_ptr(p):
++ *	returns p while inhibiting the __free().
++ *
++ * Ex.
++ *
++ * DEFINE_FREE(kfree, void *, if (_T) kfree(_T))
++ *
++ *	struct obj *p __free(kfree) = kmalloc(...);
++ *	if (!p)
++ *		return NULL;
++ *
++ *	if (!init_obj(p))
++ *		return NULL;
++ *
++ *	return_ptr(p);
++ */
++
++#define DEFINE_FREE(_name, _type, _free) \
++	static inline void __free_##_name(void *p) { _type _T = *(_type *)p; _free; }
++
++#define __free(_name)	__cleanup(__free_##_name)
++
++#define no_free_ptr(p) \
++	({ __auto_type __ptr = (p); (p) = NULL; __ptr; })
++
++#define return_ptr(p)	return no_free_ptr(p)
++
++
++/*
++ * DEFINE_CLASS(name, type, exit, init, init_args...):
++ *	helper to define the destructor and constructor for a type.
++ *	@exit is an expression using '_T' -- similar to FREE above.
++ *	@init is an expression in @init_args resulting in @type
++ *
++ * EXTEND_CLASS(name, ext, init, init_args...):
++ *	extends class @name to @name@ext with the new constructor
++ *
++ * CLASS(name, var)(args...):
++ *	declare the variable @var as an instance of the named class
++ *
++ * Ex.
++ *
++ * DEFINE_CLASS(fdget, struct fd, fdput(_T), fdget(fd), int fd)
++ *
++ *	CLASS(fdget, f)(fd);
++ *	if (!f.file)
++ *		return -EBADF;
++ *
++ *	// use 'f' without concern
++ */
++
++#define DEFINE_CLASS(_name, _type, _exit, _init, _init_args...)		\
++typedef _type class_##_name##_t;					\
++static inline void class_##_name##_destructor(_type *p)			\
++{ _type _T = *p; _exit; }						\
++static inline _type class_##_name##_constructor(_init_args)		\
++{ _type t = _init; return t; }
++
++#define EXTEND_CLASS(_name, ext, _init, _init_args...)			\
++typedef class_##_name##_t class_##_name##ext##_t;			\
++static inline void class_##_name##ext##_destructor(class_##_name##_t *p)\
++{ class_##_name##_destructor(p); }					\
++static inline class_##_name##_t class_##_name##ext##_constructor(_init_args) \
++{ class_##_name##_t t = _init; return t; }
++
++#define CLASS(_name, var)						\
++	class_##_name##_t var __cleanup(class_##_name##_destructor) =	\
++		class_##_name##_constructor
++
++
++/*
++ * DEFINE_GUARD(name, type, lock, unlock):
++ *	trivial wrapper around DEFINE_CLASS() above specifically
++ *	for locks.
++ *
++ * guard(name):
++ *	an anonymous instance of the (guard) class
++ *
++ * scoped_guard (name, args...) { }:
++ *	similar to CLASS(name, scope)(args), except the variable (with the
++ *	explicit name 'scope') is declard in a for-loop such that its scope is
++ *	bound to the next (compound) statement.
++ *
++ */
++
++#define DEFINE_GUARD(_name, _type, _lock, _unlock) \
++	DEFINE_CLASS(_name, _type, _unlock, ({ _lock; _T; }), _type _T)
++
++#define guard(_name) \
++	CLASS(_name, __UNIQUE_ID(guard))
++
++#define scoped_guard(_name, args...)					\
++	for (CLASS(_name, scope)(args),					\
++	     *done = NULL; !done; done = (void *)1)
++
++/*
++ * Additional helper macros for generating lock guards with types, either for
++ * locks that don't have a native type (eg. RCU, preempt) or those that need a
++ * 'fat' pointer (eg. spin_lock_irqsave).
++ *
++ * DEFINE_LOCK_GUARD_0(name, lock, unlock, ...)
++ * DEFINE_LOCK_GUARD_1(name, type, lock, unlock, ...)
++ *
++ * will result in the following type:
++ *
++ *   typedef struct {
++ *	type *lock;		// 'type := void' for the _0 variant
++ *	__VA_ARGS__;
++ *   } class_##name##_t;
++ *
++ * As above, both _lock and _unlock are statements, except this time '_T' will
++ * be a pointer to the above struct.
++ */
++
++#define __DEFINE_UNLOCK_GUARD(_name, _type, _unlock, ...)		\
++typedef struct {							\
++	_type *lock;							\
++	__VA_ARGS__;							\
++} class_##_name##_t;							\
++									\
++static inline void class_##_name##_destructor(class_##_name##_t *_T)	\
++{									\
++	if (_T->lock) { _unlock; }					\
++}
++
++
++#define __DEFINE_LOCK_GUARD_1(_name, _type, _lock)			\
++static inline class_##_name##_t class_##_name##_constructor(_type *l)	\
++{									\
++	class_##_name##_t _t = { .lock = l }, *_T = &_t;		\
++	_lock;								\
++	return _t;							\
++}
++
++#define __DEFINE_LOCK_GUARD_0(_name, _lock)				\
++static inline class_##_name##_t class_##_name##_constructor(void)	\
++{									\
++	class_##_name##_t _t = { .lock = (void*)1 },			\
++			 *_T __maybe_unused = &_t;			\
++	_lock;								\
++	return _t;							\
++}
++
++#define DEFINE_LOCK_GUARD_1(_name, _type, _lock, _unlock, ...)		\
++__DEFINE_UNLOCK_GUARD(_name, _type, _unlock, __VA_ARGS__)		\
++__DEFINE_LOCK_GUARD_1(_name, _type, _lock)
++
++#define DEFINE_LOCK_GUARD_0(_name, _lock, _unlock, ...)			\
++__DEFINE_UNLOCK_GUARD(_name, void, _unlock, __VA_ARGS__)		\
++__DEFINE_LOCK_GUARD_0(_name, _lock)
++
++#endif /* __LINUX_GUARDS_H */
+diff -uprN -x .DS_Store a/include/linux/compiler-clang.h b/include/linux/compiler-clang.h
+--- a/include/linux/compiler-clang.h	2026-07-09 15:40:05
++++ b/include/linux/compiler-clang.h	2026-07-09 15:40:07
+@@ -5,6 +5,15 @@
+ 
+ /* Compiler specific definitions for Clang compiler */
+ 
++/*
++ * Clang prior to 17 is being silly and considers many __cleanup() variables
++ * as unused (because they are, their sole purpose is to go out of scope).
++ *
++ * https://reviews.llvm.org/D152180
++ */
++#undef __cleanup
++#define __cleanup(func) __maybe_unused __attribute__((__cleanup__(func)))
++
+ /* same as gcc, this was present in clang-2.6 so we can assume it works
+  * with any version that can compile the kernel
+  */
+diff -uprN -x .DS_Store a/include/linux/compiler_attributes.h b/include/linux/compiler_attributes.h
+--- a/include/linux/compiler_attributes.h	2026-07-09 15:40:04
++++ b/include/linux/compiler_attributes.h	2026-07-09 15:40:07
+@@ -76,6 +76,12 @@
+ #endif
+ 
+ /*
++ *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-cleanup-variable-attribute
++ * clang: https://clang.llvm.org/docs/AttributeReference.html#cleanup
++ */
++#define __cleanup(func)			__attribute__((__cleanup__(func)))
++
++/*
+  *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-cold-function-attribute
+  *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Label-Attributes.html#index-cold-label-attribute
+  */
+diff -uprN -x .DS_Store a/include/linux/spinlock.h b/include/linux/spinlock.h
+--- a/include/linux/spinlock.h	2026-07-09 15:40:06
++++ b/include/linux/spinlock.h	2026-07-09 15:40:07
+@@ -3,6 +3,8 @@
+ #define __LINUX_SPINLOCK_H
+ #define __LINUX_INSIDE_SPINLOCK_H
+ 
++#include <linux/cleanup.h>
++
+ /*
+  * include/linux/spinlock.h - generic spinlock/rwlock declarations
+  *
+@@ -492,6 +494,36 @@ void free_bucket_spinlocks(spinlock_t *locks);
+ 	})
+ 
+ void free_bucket_spinlocks(spinlock_t *locks);
++
++DEFINE_LOCK_GUARD_1(raw_spinlock, raw_spinlock_t,
++		    raw_spin_lock(_T->lock),
++		    raw_spin_unlock(_T->lock))
++
++DEFINE_LOCK_GUARD_1(raw_spinlock_nested, raw_spinlock_t,
++		    raw_spin_lock_nested(_T->lock, SINGLE_DEPTH_NESTING),
++		    raw_spin_unlock(_T->lock))
++
++DEFINE_LOCK_GUARD_1(raw_spinlock_irq, raw_spinlock_t,
++		    raw_spin_lock_irq(_T->lock),
++		    raw_spin_unlock_irq(_T->lock))
++
++DEFINE_LOCK_GUARD_1(raw_spinlock_irqsave, raw_spinlock_t,
++		    raw_spin_lock_irqsave(_T->lock, _T->flags),
++		    raw_spin_unlock_irqrestore(_T->lock, _T->flags),
++		    unsigned long flags)
++
++DEFINE_LOCK_GUARD_1(spinlock, spinlock_t,
++		    spin_lock(_T->lock),
++		    spin_unlock(_T->lock))
++
++DEFINE_LOCK_GUARD_1(spinlock_irq, spinlock_t,
++		    spin_lock_irq(_T->lock),
++		    spin_unlock(_T->lock))
++
++DEFINE_LOCK_GUARD_1(spinlock_irqsave, spinlock_t,
++		    spin_lock_irqsave(_T->lock, _T->flags),
++		    spin_unlock_irqrestore(_T->lock, _T->flags),
++		    unsigned long flags)
+ 
+ #undef __LINUX_INSIDE_SPINLOCK_H
+ #endif /* __LINUX_SPINLOCK_H */

--- a/security_patch/cve-2026-43499-rtmutex-5.10.patch
+++ b/security_patch/cve-2026-43499-rtmutex-5.10.patch
@@ -1,0 +1,43 @@
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1061,21 +1061,27 @@
+  *
+  * Must be called with lock->wait_lock held and interrupts disabled. I must
+  * have just failed to try_to_take_rt_mutex().
++ *
++ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
+  */
+ static void remove_waiter(struct rt_mutex *lock,
+ 			  struct rt_mutex_waiter *waiter)
+ {
+ 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
+ 	struct task_struct *owner = rt_mutex_owner(lock);
++	struct task_struct *waiter_task = waiter->task;
+ 	struct rt_mutex *next_lock;
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
+-	raw_spin_lock(&current->pi_lock);
+-	rt_mutex_dequeue(lock, waiter);
+-	current->pi_blocked_on = NULL;
+-	raw_spin_unlock(&current->pi_lock);
++	if (!waiter_task) /* never enqueued */
++		return;
+ 
++	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
++		rt_mutex_dequeue(lock, waiter);
++		waiter_task->pi_blocked_on = NULL;
++	}
++
+ 	/*
+ 	 * Only update priority if the waiter was the highest priority
+ 	 * waiter of the lock and there is an owner to update.
+@@ -1110,7 +1116,7 @@
+ 	raw_spin_unlock_irq(&lock->wait_lock);
+ 
+ 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
+-				   next_lock, NULL, current);
++				   next_lock, NULL, waiter_task);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ }

--- a/security_patch/cve-2026-43499-rtmutex-5.15.patch
+++ b/security_patch/cve-2026-43499-rtmutex-5.15.patch
@@ -1,0 +1,43 @@
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1500,21 +1500,27 @@
+  *
+  * Must be called with lock->wait_lock held and interrupts disabled. It must
+  * have just failed to try_to_take_rt_mutex().
++ *
++ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
+  */
+ static void __sched remove_waiter(struct rt_mutex_base *lock,
+ 				  struct rt_mutex_waiter *waiter)
+ {
+ 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
+ 	struct task_struct *owner = rt_mutex_owner(lock);
++	struct task_struct *waiter_task = waiter->task;
+ 	struct rt_mutex_base *next_lock;
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
+-	raw_spin_lock(&current->pi_lock);
+-	rt_mutex_dequeue(lock, waiter);
+-	current->pi_blocked_on = NULL;
+-	raw_spin_unlock(&current->pi_lock);
++	if (!waiter_task) /* never enqueued */
++		return;
+ 
++	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
++		rt_mutex_dequeue(lock, waiter);
++		waiter_task->pi_blocked_on = NULL;
++	}
++
+ 	/*
+ 	 * Only update priority if the waiter was the highest priority
+ 	 * waiter of the lock and there is an owner to update.
+@@ -1549,7 +1555,7 @@
+ 	raw_spin_unlock_irq(&lock->wait_lock);
+ 
+ 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
+-				   next_lock, NULL, current);
++				   next_lock, NULL, waiter_task);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ }

--- a/security_patch/cve-2026-43499-rtmutex-6.1-6.6.patch
+++ b/security_patch/cve-2026-43499-rtmutex-6.1-6.6.patch
@@ -1,0 +1,43 @@
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1511,21 +1511,27 @@
+  *
+  * Must be called with lock->wait_lock held and interrupts disabled. It must
+  * have just failed to try_to_take_rt_mutex().
++ *
++ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
+  */
+ static void __sched remove_waiter(struct rt_mutex_base *lock,
+ 				  struct rt_mutex_waiter *waiter)
+ {
+ 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
+ 	struct task_struct *owner = rt_mutex_owner(lock);
++	struct task_struct *waiter_task = waiter->task;
+ 	struct rt_mutex_base *next_lock;
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
+-	raw_spin_lock(&current->pi_lock);
+-	rt_mutex_dequeue(lock, waiter);
+-	current->pi_blocked_on = NULL;
+-	raw_spin_unlock(&current->pi_lock);
++	if (!waiter_task) /* never enqueued */
++		return;
+ 
++	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
++		rt_mutex_dequeue(lock, waiter);
++		waiter_task->pi_blocked_on = NULL;
++	}
++
+ 	/*
+ 	 * Only update priority if the waiter was the highest priority
+ 	 * waiter of the lock and there is an owner to update.
+@@ -1560,7 +1566,7 @@
+ 	raw_spin_unlock_irq(&lock->wait_lock);
+ 
+ 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
+-				   next_lock, NULL, current);
++				   next_lock, NULL, waiter_task);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ }

--- a/security_patch/cve-2026-43499-rtmutex-6.12.patch
+++ b/security_patch/cve-2026-43499-rtmutex-6.12.patch
@@ -1,0 +1,39 @@
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1536,20 +1536,23 @@ static bool rtmutex_spin_on_owner(struct rt_mutex_base
+  *
+  * Must be called with lock->wait_lock held and interrupts disabled. It must
+  * have just failed to try_to_take_rt_mutex().
++ *
++ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
+  */
+ static void __sched remove_waiter(struct rt_mutex_base *lock,
+ 				  struct rt_mutex_waiter *waiter)
+ {
+ 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
+ 	struct task_struct *owner = rt_mutex_owner(lock);
++	struct task_struct *waiter_task = waiter->task;
+ 	struct rt_mutex_base *next_lock;
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
+-	raw_spin_lock(&current->pi_lock);
+-	rt_mutex_dequeue(lock, waiter);
+-	current->pi_blocked_on = NULL;
+-	raw_spin_unlock(&current->pi_lock);
++	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
++		rt_mutex_dequeue(lock, waiter);
++		waiter_task->pi_blocked_on = NULL;
++	}
+ 
+ 	/*
+ 	 * Only update priority if the waiter was the highest priority
+@@ -1585,7 +1588,7 @@ static void __sched remove_waiter(struct rt_mutex_base
+ 	raw_spin_unlock_irq(&lock->wait_lock);
+ 
+ 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
+-				   next_lock, NULL, current);
++				   next_lock, NULL, waiter_task);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ }

--- a/security_patch/scoped_guard_cleanup.h
+++ b/security_patch/scoped_guard_cleanup.h
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __LINUX_GUARDS_H
+#define __LINUX_GUARDS_H
+
+#include <linux/compiler.h>
+
+/*
+ * DEFINE_FREE(name, type, free):
+ *	simple helper macro that defines the required wrapper for a __free()
+ *	based cleanup function. @free is an expression using '_T' to access
+ *	the variable.
+ *
+ * __free(name):
+ *	variable attribute to add a scoped based cleanup to the variable.
+ *
+ * no_free_ptr(var):
+ *	like a non-atomic xchg(var, NULL), such that the cleanup function will
+ *	be inhibited -- provided it sanely deals with a NULL value.
+ *
+ * return_ptr(p):
+ *	returns p while inhibiting the __free().
+ *
+ * Ex.
+ *
+ * DEFINE_FREE(kfree, void *, if (_T) kfree(_T))
+ *
+ *	struct obj *p __free(kfree) = kmalloc(...);
+ *	if (!p)
+ *		return NULL;
+ *
+ *	if (!init_obj(p))
+ *		return NULL;
+ *
+ *	return_ptr(p);
+ */
+
+#define DEFINE_FREE(_name, _type, _free) \
+	static inline void __free_##_name(void *p) { _type _T = *(_type *)p; _free; }
+
+#define __free(_name)	__cleanup(__free_##_name)
+
+#define no_free_ptr(p) \
+	({ __auto_type __ptr = (p); (p) = NULL; __ptr; })
+
+#define return_ptr(p)	return no_free_ptr(p)
+
+
+/*
+ * DEFINE_CLASS(name, type, exit, init, init_args...):
+ *	helper to define the destructor and constructor for a type.
+ *	@exit is an expression using '_T' -- similar to FREE above.
+ *	@init is an expression in @init_args resulting in @type
+ *
+ * EXTEND_CLASS(name, ext, init, init_args...):
+ *	extends class @name to @name@ext with the new constructor
+ *
+ * CLASS(name, var)(args...):
+ *	declare the variable @var as an instance of the named class
+ *
+ * Ex.
+ *
+ * DEFINE_CLASS(fdget, struct fd, fdput(_T), fdget(fd), int fd)
+ *
+ *	CLASS(fdget, f)(fd);
+ *	if (!f.file)
+ *		return -EBADF;
+ *
+ *	// use 'f' without concern
+ */
+
+#define DEFINE_CLASS(_name, _type, _exit, _init, _init_args...)		\
+typedef _type class_##_name##_t;					\
+static inline void class_##_name##_destructor(_type *p)			\
+{ _type _T = *p; _exit; }						\
+static inline _type class_##_name##_constructor(_init_args)		\
+{ _type t = _init; return t; }
+
+#define EXTEND_CLASS(_name, ext, _init, _init_args...)			\
+typedef class_##_name##_t class_##_name##ext##_t;			\
+static inline void class_##_name##ext##_destructor(class_##_name##_t *p)\
+{ class_##_name##_destructor(p); }					\
+static inline class_##_name##_t class_##_name##ext##_constructor(_init_args) \
+{ class_##_name##_t t = _init; return t; }
+
+#define CLASS(_name, var)						\
+	class_##_name##_t var __cleanup(class_##_name##_destructor) =	\
+		class_##_name##_constructor
+
+
+/*
+ * DEFINE_GUARD(name, type, lock, unlock):
+ *	trivial wrapper around DEFINE_CLASS() above specifically
+ *	for locks.
+ *
+ * guard(name):
+ *	an anonymous instance of the (guard) class
+ *
+ * scoped_guard (name, args...) { }:
+ *	similar to CLASS(name, scope)(args), except the variable (with the
+ *	explicit name 'scope') is declard in a for-loop such that its scope is
+ *	bound to the next (compound) statement.
+ *
+ */
+
+#define DEFINE_GUARD(_name, _type, _lock, _unlock) \
+	DEFINE_CLASS(_name, _type, _unlock, ({ _lock; _T; }), _type _T)
+
+#define guard(_name) \
+	CLASS(_name, __UNIQUE_ID(guard))
+
+#define scoped_guard(_name, args...)					\
+	for (CLASS(_name, scope)(args),					\
+	     *done = NULL; !done; done = (void *)1)
+
+/*
+ * Additional helper macros for generating lock guards with types, either for
+ * locks that don't have a native type (eg. RCU, preempt) or those that need a
+ * 'fat' pointer (eg. spin_lock_irqsave).
+ *
+ * DEFINE_LOCK_GUARD_0(name, lock, unlock, ...)
+ * DEFINE_LOCK_GUARD_1(name, type, lock, unlock, ...)
+ *
+ * will result in the following type:
+ *
+ *   typedef struct {
+ *	type *lock;		// 'type := void' for the _0 variant
+ *	__VA_ARGS__;
+ *   } class_##name##_t;
+ *
+ * As above, both _lock and _unlock are statements, except this time '_T' will
+ * be a pointer to the above struct.
+ */
+
+#define __DEFINE_UNLOCK_GUARD(_name, _type, _unlock, ...)		\
+typedef struct {							\
+	_type *lock;							\
+	__VA_ARGS__;							\
+} class_##_name##_t;							\
+									\
+static inline void class_##_name##_destructor(class_##_name##_t *_T)	\
+{									\
+	if (_T->lock) { _unlock; }					\
+}
+
+
+#define __DEFINE_LOCK_GUARD_1(_name, _type, _lock)			\
+static inline class_##_name##_t class_##_name##_constructor(_type *l)	\
+{									\
+	class_##_name##_t _t = { .lock = l }, *_T = &_t;		\
+	_lock;								\
+	return _t;							\
+}
+
+#define __DEFINE_LOCK_GUARD_0(_name, _lock)				\
+static inline class_##_name##_t class_##_name##_constructor(void)	\
+{									\
+	class_##_name##_t _t = { .lock = (void*)1 },			\
+			 *_T __maybe_unused = &_t;			\
+	_lock;								\
+	return _t;							\
+}
+
+#define DEFINE_LOCK_GUARD_1(_name, _type, _lock, _unlock, ...)		\
+__DEFINE_UNLOCK_GUARD(_name, _type, _unlock, __VA_ARGS__)		\
+__DEFINE_LOCK_GUARD_1(_name, _type, _lock)
+
+#define DEFINE_LOCK_GUARD_0(_name, _lock, _unlock, ...)			\
+__DEFINE_UNLOCK_GUARD(_name, void, _unlock, __VA_ARGS__)		\
+__DEFINE_LOCK_GUARD_0(_name, _lock)
+
+#endif /* __LINUX_GUARDS_H */

--- a/security_patch/scoped_guard_compiler_clang.txt
+++ b/security_patch/scoped_guard_compiler_clang.txt
@@ -1,0 +1,8 @@
+/*
+ * Clang prior to 17 is being silly and considers many __cleanup() variables
+ * as unused (because they are, their sole purpose is to go out of scope).
+ *
+ * https://reviews.llvm.org/D152180
+ */
+#undef __cleanup
+#define __cleanup(func) __maybe_unused __attribute__((__cleanup__(func)))

--- a/security_patch/scoped_guard_compiler_cleanup.txt
+++ b/security_patch/scoped_guard_compiler_cleanup.txt
@@ -1,0 +1,5 @@
+/*
+ *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-cleanup-variable-attribute
+ * clang: https://clang.llvm.org/docs/AttributeReference.html#cleanup
+ */
+#define __cleanup(func)			__attribute__((__cleanup__(func)))

--- a/security_patch/scoped_guard_spinlock_guards.txt
+++ b/security_patch/scoped_guard_spinlock_guards.txt
@@ -1,0 +1,30 @@
+
+DEFINE_LOCK_GUARD_1(raw_spinlock, raw_spinlock_t,
+		    raw_spin_lock(_T->lock),
+		    raw_spin_unlock(_T->lock))
+
+DEFINE_LOCK_GUARD_1(raw_spinlock_nested, raw_spinlock_t,
+		    raw_spin_lock_nested(_T->lock, SINGLE_DEPTH_NESTING),
+		    raw_spin_unlock(_T->lock))
+
+DEFINE_LOCK_GUARD_1(raw_spinlock_irq, raw_spinlock_t,
+		    raw_spin_lock_irq(_T->lock),
+		    raw_spin_unlock_irq(_T->lock))
+
+DEFINE_LOCK_GUARD_1(raw_spinlock_irqsave, raw_spinlock_t,
+		    raw_spin_lock_irqsave(_T->lock, _T->flags),
+		    raw_spin_unlock_irqrestore(_T->lock, _T->flags),
+		    unsigned long flags)
+
+DEFINE_LOCK_GUARD_1(spinlock, spinlock_t,
+		    spin_lock(_T->lock),
+		    spin_unlock(_T->lock))
+
+DEFINE_LOCK_GUARD_1(spinlock_irq, spinlock_t,
+		    spin_lock_irq(_T->lock),
+		    spin_unlock_irq(_T->lock))
+
+DEFINE_LOCK_GUARD_1(spinlock_irqsave, spinlock_t,
+		    spin_lock_irqsave(_T->lock, _T->flags),
+		    spin_unlock_irqrestore(_T->lock, _T->flags),
+		    unsigned long flags)


### PR DESCRIPTION
Automatically detect legacy kernel versions that either lack the fix for CVE-2026-43499 or include the fix for CVE-2026-43499 but not CVE-2026-53163, and backport the corresponding patches

自动识别并给不包含CVE-2026-43499修复或仅包含CVE-2026-43499但不包含CVE-2026-53163修复的旧版本内核回移修复补丁