### PR TITLE
Inject NTSync kernel patches into build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -879,6 +879,18 @@ jobs:
       - name: 备份基准 defconfig
         run: cp "$DEFCONFIG" "$DEFCONFIG.orig"
 
+      - name: 注入NTsync内核配置
+        run: |
+            cd "$KERNEL_ROOT"
+            cd ./common
+            wget "https://raw.githubusercontent.com/Goldzxcbug/Droidspaces_Kernel_patch/refs/heads/main/NTsync/ntsync_base.patch"
+            wget "https://raw.githubusercontent.com/Goldzxcbug/Droidspaces_Kernel_patch/refs/heads/main/NTsync/ntsync_compat_android12-5.10.patch"
+            patch -p1 < 'ntsync_base.patch'
+            patch -p1 < 'ntsync_compat_android12-5.10.patch'            
+            cd ../
+            #开启NTsync内核配置
+            echo "CONFIG_NTSYNC=y" >> ./common/arch/arm64/configs/gki_defconfig
+        
       - name: 集成 Droidspaces 支持
         if: inputs.droidspaces != 'off'
         working-directory: ${{ env.KERNEL_ROOT }}/common
@@ -996,7 +1008,7 @@ jobs:
           }
 
           if [[ "${{ inputs.android_version }}" == "android15" && "${{ inputs.kernel_version }}" == "6.6" ]]; then
-            # 1. 开启用户命名空间（必须）
+            1. 开启用户命名空间（必须）
             # enable_config_if_defined CONFIG_USER_NS
             # 2. 关闭安卓严格网络控制（必须）
             disable_config CONFIG_ANDROID_PARANOID_NETWORK


### PR DESCRIPTION
Add steps to download and apply NTSync kernel patches, enabling NTSync configuration in the build process.