### PR TITLE
fix（6.12）： 修复 FS/open.c getname_flags 三参数调用导致编译失败

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -873,6 +873,12 @@ jobs:
                 sed -i 's/defined(CONFIG_KSU_MANUAL_HOOK))/!defined(CONFIG_KSU_SUSFS) \&\& defined(CONFIG_KSU_MANUAL_HOOK))/' "$SETUID_HOOK"
                 echo "已修复 setuid_hook.c 重复定义问题"
               fi
+              
+              # 修复 6.12 getname_flags 三参数调用（ACK 6.12 声明为 2 参数）
+              if grep -qF 'getname_flags(filename, lookup_flags, NULL)' ./fs/open.c; then
+                 sed -i 's/getname_flags(filename, lookup_flags, NULL)/getname_flags(filename, lookup_flags)/' ./fs/open.c
+                 echo "已修复 fs/open.c getname_flags 三参数问题"
+              fi
 
               # 修复 6.12.58+: exec.c 头部上下文变化导致 SUSFS 补丁漏掉 susfs_def.h
               if grep -q 'susfs_is_current_proc_umounted' ./fs/exec.c && ! grep -qF '#include <linux/susfs_def.h>' ./fs/exec.c; then


### PR DESCRIPTION
ACK 6.12 的 getname_flags 声明为 2 参数，但 do_faccessat 调用传了 3 参数（多了 NULL），导致 6.12 全部子版本 ReSukiSU 构建失败：
  fs/open.c:507: error: too many arguments to function call, expected 2, have 3

在 Android 16-6.12 修复块中新增 sed，将三参数调用修正为两参数。